### PR TITLE
fix(*): error by `pod spec lint`

### DIFF
--- a/Bucketeer/Sources/proto/account/account_service.grpc.swift
+++ b/Bucketeer/Sources/proto/account/account_service.grpc.swift
@@ -20,10 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
 import SwiftProtobuf
 
 

--- a/Bucketeer/Sources/proto/auditlog/auditlog_service.grpc.swift
+++ b/Bucketeer/Sources/proto/auditlog/auditlog_service.grpc.swift
@@ -20,10 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
 import SwiftProtobuf
 
 

--- a/Bucketeer/Sources/proto/auth/auth_service.grpc.swift
+++ b/Bucketeer/Sources/proto/auth/auth_service.grpc.swift
@@ -20,10 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
 import SwiftProtobuf
 
 

--- a/Bucketeer/Sources/proto/autoops/autoops_service.grpc.swift
+++ b/Bucketeer/Sources/proto/autoops/autoops_service.grpc.swift
@@ -20,10 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
 import SwiftProtobuf
 
 

--- a/Bucketeer/Sources/proto/environment/environment_service.grpc.swift
+++ b/Bucketeer/Sources/proto/environment/environment_service.grpc.swift
@@ -20,10 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
 import SwiftProtobuf
 
 

--- a/Bucketeer/Sources/proto/eventcounter/eventcounter_service.grpc.swift
+++ b/Bucketeer/Sources/proto/eventcounter/eventcounter_service.grpc.swift
@@ -20,10 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
 import SwiftProtobuf
 
 

--- a/Bucketeer/Sources/proto/eventcounter/eventcounter_streaming_service.grpc.swift
+++ b/Bucketeer/Sources/proto/eventcounter/eventcounter_streaming_service.grpc.swift
@@ -20,10 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
 import SwiftProtobuf
 
 

--- a/Bucketeer/Sources/proto/experiment/experiment_service.grpc.swift
+++ b/Bucketeer/Sources/proto/experiment/experiment_service.grpc.swift
@@ -20,10 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
 import SwiftProtobuf
 
 

--- a/Bucketeer/Sources/proto/feature/feature_service.grpc.swift
+++ b/Bucketeer/Sources/proto/feature/feature_service.grpc.swift
@@ -20,10 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
 import SwiftProtobuf
 
 

--- a/Bucketeer/Sources/proto/gateway/gateway_service.grpc.swift
+++ b/Bucketeer/Sources/proto/gateway/gateway_service.grpc.swift
@@ -20,10 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
 import SwiftProtobuf
 
 

--- a/Bucketeer/Sources/proto/notification/notification_service.grpc.swift
+++ b/Bucketeer/Sources/proto/notification/notification_service.grpc.swift
@@ -20,10 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
 import SwiftProtobuf
 
 

--- a/Bucketeer/Sources/proto/push/push_service.grpc.swift
+++ b/Bucketeer/Sources/proto/push/push_service.grpc.swift
@@ -20,10 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
 import SwiftProtobuf
 
 

--- a/Bucketeer/Sources/proto/test/test_service.grpc.swift
+++ b/Bucketeer/Sources/proto/test/test_service.grpc.swift
@@ -20,10 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
 import SwiftProtobuf
 
 

--- a/Bucketeer/Sources/proto/user/user_service.grpc.swift
+++ b/Bucketeer/Sources/proto/user/user_service.grpc.swift
@@ -20,10 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
 import SwiftProtobuf
 
 

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ use_frameworks!
 workspace 'Bucketeer'
 
 def shared_pods
-    pod 'gRPC-Swift', '1.0.0-alpha.17'
+    pod 'gRPC-Swift', '1.0.0-alpha.19'
 end
 
 target 'Bucketeer' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,63 +1,63 @@
 PODS:
-  - CGRPCZlib (1.0.0-alpha.17)
-  - CNIOAtomics (2.19.0)
-  - CNIOBoringSSL (2.8.0)
-  - CNIOBoringSSLShims (2.8.0):
-    - CNIOBoringSSL (= 2.8.0)
-  - CNIODarwin (2.19.0)
-  - CNIOHTTPParser (2.19.0)
-  - CNIOLinux (2.19.0)
-  - CNIOSHA1 (2.19.0)
-  - gRPC-Swift (1.0.0-alpha.17):
-    - CGRPCZlib (= 1.0.0-alpha.17)
+  - CGRPCZlib (1.0.0-alpha.19)
+  - CNIOAtomics (2.22.0)
+  - CNIOBoringSSL (2.9.1)
+  - CNIOBoringSSLShims (2.9.1):
+    - CNIOBoringSSL (= 2.9.1)
+  - CNIODarwin (2.22.0)
+  - CNIOHTTPParser (2.22.0)
+  - CNIOLinux (2.22.0)
+  - CNIOSHA1 (2.22.0)
+  - gRPC-Swift (1.0.0-alpha.19):
+    - CGRPCZlib (= 1.0.0-alpha.19)
     - Logging (< 2, >= 1.2.0)
     - SwiftNIO (< 3, >= 2.19.0)
     - SwiftNIOHTTP2 (< 2, >= 1.12.2)
     - SwiftNIOSSL (< 3, >= 2.8.0)
     - SwiftNIOTransportServices (< 2, >= 1.6.0)
     - SwiftProtobuf (< 2, >= 1.9.0)
-  - Logging (1.2.0)
-  - SwiftNIO (2.19.0):
-    - CNIOAtomics (= 2.19.0)
-    - CNIODarwin (= 2.19.0)
-    - CNIOLinux (= 2.19.0)
-    - CNIOSHA1 (= 2.19.0)
-    - SwiftNIOConcurrencyHelpers (= 2.19.0)
-  - SwiftNIOConcurrencyHelpers (2.19.0):
-    - CNIOAtomics (= 2.19.0)
-  - SwiftNIOFoundationCompat (2.19.0):
-    - SwiftNIO (= 2.19.0)
-  - SwiftNIOHPACK (1.12.3):
-    - SwiftNIO (< 3, >= 2.19.0)
-    - SwiftNIOConcurrencyHelpers (< 3, >= 2.19.0)
-    - SwiftNIOHTTP1 (< 3, >= 2.19.0)
-  - SwiftNIOHTTP1 (2.19.0):
-    - CNIOHTTPParser (= 2.19.0)
-    - SwiftNIO (= 2.19.0)
-    - SwiftNIOConcurrencyHelpers (= 2.19.0)
-  - SwiftNIOHTTP2 (1.12.3):
-    - SwiftNIO (< 3, >= 2.19.0)
-    - SwiftNIOConcurrencyHelpers (< 3, >= 2.19.0)
-    - SwiftNIOHPACK (= 1.12.3)
-    - SwiftNIOHTTP1 (< 3, >= 2.19.0)
-    - SwiftNIOTLS (< 3, >= 2.19.0)
-  - SwiftNIOSSL (2.8.0):
-    - CNIOBoringSSL (= 2.8.0)
-    - CNIOBoringSSLShims (= 2.8.0)
-    - SwiftNIO (< 3, >= 2.19.0)
-    - SwiftNIOConcurrencyHelpers (< 3, >= 2.19.0)
-    - SwiftNIOTLS (< 3, >= 2.19.0)
-  - SwiftNIOTLS (2.19.0):
-    - SwiftNIO (= 2.19.0)
-  - SwiftNIOTransportServices (1.7.0):
-    - SwiftNIO (< 3, >= 2.19.0)
-    - SwiftNIOConcurrencyHelpers (< 3, >= 2.19.0)
-    - SwiftNIOFoundationCompat (< 3, >= 2.19.0)
-    - SwiftNIOTLS (< 3, >= 2.19.0)
-  - SwiftProtobuf (1.10.2)
+  - Logging (1.4.0)
+  - SwiftNIO (2.22.0):
+    - CNIOAtomics (= 2.22.0)
+    - CNIODarwin (= 2.22.0)
+    - CNIOLinux (= 2.22.0)
+    - CNIOSHA1 (= 2.22.0)
+    - SwiftNIOConcurrencyHelpers (= 2.22.0)
+  - SwiftNIOConcurrencyHelpers (2.22.0):
+    - CNIOAtomics (= 2.22.0)
+  - SwiftNIOFoundationCompat (2.22.0):
+    - SwiftNIO (= 2.22.0)
+  - SwiftNIOHPACK (1.14.1):
+    - SwiftNIO (< 3, >= 2.22.0)
+    - SwiftNIOConcurrencyHelpers (< 3, >= 2.22.0)
+    - SwiftNIOHTTP1 (< 3, >= 2.22.0)
+  - SwiftNIOHTTP1 (2.22.0):
+    - CNIOHTTPParser (= 2.22.0)
+    - SwiftNIO (= 2.22.0)
+    - SwiftNIOConcurrencyHelpers (= 2.22.0)
+  - SwiftNIOHTTP2 (1.14.1):
+    - SwiftNIO (< 3, >= 2.22.0)
+    - SwiftNIOConcurrencyHelpers (< 3, >= 2.22.0)
+    - SwiftNIOHPACK (= 1.14.1)
+    - SwiftNIOHTTP1 (< 3, >= 2.22.0)
+    - SwiftNIOTLS (< 3, >= 2.22.0)
+  - SwiftNIOSSL (2.9.1):
+    - CNIOBoringSSL (= 2.9.1)
+    - CNIOBoringSSLShims (= 2.9.1)
+    - SwiftNIO (< 3, >= 2.22.0)
+    - SwiftNIOConcurrencyHelpers (< 3, >= 2.22.0)
+    - SwiftNIOTLS (< 3, >= 2.22.0)
+  - SwiftNIOTLS (2.22.0):
+    - SwiftNIO (= 2.22.0)
+  - SwiftNIOTransportServices (1.9.0):
+    - SwiftNIO (< 3, >= 2.22.0)
+    - SwiftNIOConcurrencyHelpers (< 3, >= 2.22.0)
+    - SwiftNIOFoundationCompat (< 3, >= 2.22.0)
+    - SwiftNIOTLS (< 3, >= 2.22.0)
+  - SwiftProtobuf (1.12.0)
 
 DEPENDENCIES:
-  - gRPC-Swift (= 1.0.0-alpha.17)
+  - gRPC-Swift (= 1.0.0-alpha.19)
 
 SPEC REPOS:
   trunk:
@@ -83,27 +83,27 @@ SPEC REPOS:
     - SwiftProtobuf
 
 SPEC CHECKSUMS:
-  CGRPCZlib: 245283cd656bf0c309a48a887c27865d6f54f7ef
-  CNIOAtomics: 0d87ebc16f126fdd9c4e68f1a37092e5fc43d531
-  CNIOBoringSSL: 00a461e12f1cb148a692df457d6122dca985accf
-  CNIOBoringSSLShims: 61d154803c5841e2abf41986df74efd25b1e1cc8
-  CNIODarwin: cf4bc6a7e61310d5d2ddb7dd80a419aa53a03047
-  CNIOHTTPParser: 56fa3561be52ba9b387ca0e11755ef5421fee8f5
-  CNIOLinux: 87a599ed230ac8dbdd2846ab989da9af685f90ef
-  CNIOSHA1: 5d878498c8a1e9eef54b849a0914ac839256dbb9
-  gRPC-Swift: 871cf2df24d9f5424763ae5af7248ed26a1b1314
-  Logging: 7838d379d234d7e5ae1265fa02804a9084caf04c
-  SwiftNIO: bcf3d3933d419095ee792e8d3b8079e41a99737b
-  SwiftNIOConcurrencyHelpers: f4390bc20d6ba994468dc5cfacbbd0f86add9104
-  SwiftNIOFoundationCompat: 12e0610d4d2a202ee04a2528d8ef0330d4f30457
-  SwiftNIOHPACK: 1266d72b8ec54df7a6b6bb8102edd3d09dd3653a
-  SwiftNIOHTTP1: 48724d9767acebc698c37c57f7c102cdf2d909fe
-  SwiftNIOHTTP2: fd11db8b30074f8887187a89a6285dba7e7a522a
-  SwiftNIOSSL: 13a36d0fb6e742574a4acab4807f0aebb3fa9b46
-  SwiftNIOTLS: acb3279174477adab836874c30008ca9fced9fce
-  SwiftNIOTransportServices: 2b8c130457110ef198e10b544b070885815db6c2
-  SwiftProtobuf: bec1ae7d686ff73dd09d79866154f4970b891410
+  CGRPCZlib: befd9b92013c647f18aa9b7d9e9231d52e1ced1b
+  CNIOAtomics: fc22c21538d19cd55cce438146ce0388684601b4
+  CNIOBoringSSL: ee7722e4355434b420eb06b3ca7535a6cfb09cf2
+  CNIOBoringSSLShims: e76fde7b7972f242e250f76dafcfdbd23be26eca
+  CNIODarwin: efb83e040e8409494d0a5beeaa711fc95e7d94e9
+  CNIOHTTPParser: c5dc715ce6b8c06049b69a9337f8b6af4b2a5ffb
+  CNIOLinux: 11f69f76c12087a0752fa8a53f32f9853ef3f4f2
+  CNIOSHA1: ff4d77269adcb89f9a962abcbee55256a29b8a36
+  gRPC-Swift: 75a7a8d7cd08177165ef971159afb84e5130cfc9
+  Logging: beeb016c9c80cf77042d62e83495816847ef108b
+  SwiftNIO: e1995d88785db2db1ad5ee4590e4206b8c2658dc
+  SwiftNIOConcurrencyHelpers: d591e7cca9f9e61d2352a13303984b86cee2b212
+  SwiftNIOFoundationCompat: ebf639c373a7a4f074a6a727ba56dad4432a00d9
+  SwiftNIOHPACK: 25e34368f9633012479e3f9ec6c94d490c5852a9
+  SwiftNIOHTTP1: 54570af50938aa7ccae65392690401fa90a762ed
+  SwiftNIOHTTP2: 0ef3020ee88321d4932bf1a1007fa91e7800cbfd
+  SwiftNIOSSL: 2967e874b40d05904edde5c540c3157621e5ecc4
+  SwiftNIOTLS: 46bb3a0ff37d6b52ae6baf5207ec3cd411da327c
+  SwiftNIOTransportServices: 801923921fbecdcde1e1c1ff38e812167d01ead1
+  SwiftProtobuf: 4ef85479c18ca85b5482b343df9c319c62bda699
 
-PODFILE CHECKSUM: fc4bba21aeaeb6562ec62256063c2f9bed4679aa
+PODFILE CHECKSUM: 4776c5f2dcba1a44e871eedc9dc05438eff837c7
 
 COCOAPODS: 1.9.3

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ brew install protobuf
 ```
 git clone git@github.com:grpc/grpc-swift.git /tmp/grpc-swift
 cd /tmp/grpc-swift
-git checkout 1.0.0-alpha.17
+git checkout 1.0.0-alpha.19
 make plugins
-cp protoc-gen-swift protoc-gen-swiftgrpc /usr/local/bin
+cp protoc-gen-swift protoc-gen-grpc-swift /usr/local/bin
 ```
 
 - [googleapis/googleapis](https://github.com/googleapis/googleapis)

--- a/Specs/template/Bucketeer.podspec
+++ b/Specs/template/Bucketeer.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
       :tag => "v#{s.version}",
   }
 
-  s.dependency "gRPC-Swift", "1.0.0-alpha.17"
+  s.dependency "gRPC-Swift", "1.0.0-alpha.19"
 
   s.license = {
     :type => "Apache License, Version 2.0",


### PR DESCRIPTION
To fix the error below, I'll update grpc-swift to 1.0.0-alpha.19.

```
 -> Bucketeer
 -> Bucketeer (1.11.0)
...
Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'SwiftNIOHPACK' from project 'Pods')
    - NOTE  | xcodebuild:  note: Execution policy exception registration failed and was skipped: Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'SwiftNIOHTTP2' from project 'Pods')
    - ERROR | xcodebuild:  gRPC-Swift/Sources/GRPC/HTTP1ToGRPCServerCodec.swift:411:75: error: ambiguous use of 'count'
    - NOTE  | xcodebuild:  Swift.String.UTF8View:2:27: note: found this candidate
    - NOTE  | xcodebuild:  Swift.Collection:5:27: note: found this candidate
Analyzed 1 podspec.
[!] The spec did not pass validation, due to 2 errors.
```