### PR TITLE
chore(*): serialize all tasks in the sdk

### DIFF
--- a/Bucketeer/Sources/APIClient.swift
+++ b/Bucketeer/Sources/APIClient.swift
@@ -23,7 +23,7 @@ final class APIClient: APIClientProtocol {
         let callOpts = CallOptions(customMetadata: metadata, timeLimit: timeLimit)
         serviceClient = Bucketeer_Gateway_GatewayClient(channel: connection, defaultCallOptions: callOpts)
     }
-    
+
     func getEvaluations(userEntity: UserEntity, userEvaluationsId: String, completion: @escaping (Result<(Bucketeer_Gateway_GetEvaluationsResponse?, CallResult), BucketeerError>) -> Void) {
         var request = Bucketeer_Gateway_GetEvaluationsRequest()
         request.user = userEntity.user
@@ -32,21 +32,21 @@ final class APIClient: APIClientProtocol {
         let call = self.serviceClient.getEvaluations(request)
         let response: Bucketeer_Gateway_GetEvaluationsResponse
         let status: GRPCStatus
+        let errorHandler: (String) -> Void = { message in
+            Logger.shared.errorLog(message)
+            completion(.failure(.unknown(message)))
+        }
         do {
             let result = try call.response.and(call.status).wait()
             response = result.0
             status = result.1
         } catch {
-            let message = "(\(Version.number)) Failed to get evaluations: \(error.localizedDescription)"
-            Logger.shared.errorLog(message)
-            completion(.failure(.unknown(message)))
+            errorHandler("(\(Version.number)) Failed to get evaluations: \(error.localizedDescription)")
             return
         }
         let callResult = CallResult(success: status.isOk, code: status.code, message: status.message)
         if callResult.isFailed {
-            let message = "(\(Version.number)) Failed to get evaluations: \(callResult)"
-            Logger.shared.errorLog(message)
-            completion(.failure(.unknown(message)))
+            errorHandler("(\(Version.number)) Failed to get evaluations: \(callResult)")
             return
         }
         completion(.success((response, callResult)))
@@ -58,21 +58,21 @@ final class APIClient: APIClientProtocol {
         let call = self.serviceClient.registerEvents(request)
         let response: Bucketeer_Gateway_RegisterEventsResponse
         let status: GRPCStatus
+        let errorHandler: (String) -> Void = { message in
+            Logger.shared.errorLog(message)
+            completion(.failure(.unknown(message)))
+        }
         do {
             let result = try call.response.and(call.status).wait()
             response = result.0
             status = result.1
         } catch {
-            let message = "(\(Version.number)) Failed to register events: \(error.localizedDescription)"
-            Logger.shared.errorLog(message)
-            completion(.failure(.unknown(message)))
+            errorHandler("(\(Version.number)) Failed to register events: \(error.localizedDescription)")
             return
         }
         let callResult = CallResult(success: status.isOk, code: status.code, message: status.message)
         if callResult.isFailed {
-            let message = "(\(Version.number)) Failed to register events: \(callResult)"
-            Logger.shared.errorLog(message)
-            completion(.failure(.unknown(message)))
+            errorHandler("(\(Version.number)) Failed to get evaluations: \(callResult)")
             return
         }
         completion(.success((response, callResult)))

--- a/Bucketeer/Sources/APIClient.swift
+++ b/Bucketeer/Sources/APIClient.swift
@@ -30,45 +30,51 @@ final class APIClient: APIClientProtocol {
         request.tag = self.config.tag
         request.userEvaluationsID = userEvaluationsId
         let call = self.serviceClient.getEvaluations(request)
-        call.response.and(call.status).whenComplete { result in
-            switch (result) {
-            case .success((let res, let status)):
-                let callResult = CallResult(success: status.isOk, code: status.code, message: status.message)
-                if callResult.isFailed {
-                    let message = "(\(Version.number)) Failed to get evaluations: \(callResult)"
-                    Logger.shared.errorLog(message)
-                    completion(.failure(.unknown(message)))
-                    return
-                }
-                completion(.success((res, callResult)))
-            case .failure(let error):
-                let message = "(\(Version.number)) Failed to get evaluations: \(error.localizedDescription)"
-                Logger.shared.errorLog(message)
-                completion(.failure(.unknown(message)))
-            }
+        let response: Bucketeer_Gateway_GetEvaluationsResponse
+        let status: GRPCStatus
+        do {
+            let result = try call.response.and(call.status).wait()
+            response = result.0
+            status = result.1
+        } catch {
+            let message = "(\(Version.number)) Failed to get evaluations: \(error.localizedDescription)"
+            Logger.shared.errorLog(message)
+            completion(.failure(.unknown(message)))
+            return
         }
+        let callResult = CallResult(success: status.isOk, code: status.code, message: status.message)
+        if callResult.isFailed {
+            let message = "(\(Version.number)) Failed to get evaluations: \(callResult)"
+            Logger.shared.errorLog(message)
+            completion(.failure(.unknown(message)))
+            return
+        }
+        completion(.success((response, callResult)))
     }
     
     func registerEvents(eventEntities: [EventEntity], completion: @escaping (Result<(Bucketeer_Gateway_RegisterEventsResponse?, CallResult), BucketeerError>) -> Void) {
         var request = Bucketeer_Gateway_RegisterEventsRequest()
         request.events = eventEntities.compactMap { try? Bucketeer_Event_Client_Event(serializedData: $0.data) }
         let call = self.serviceClient.registerEvents(request)
-        call.response.and(call.status).whenComplete { result in
-            switch (result) {
-            case .success((let res, let status)):
-                let callResult = CallResult(success: status.isOk, code: status.code, message: status.message)
-                if callResult.isFailed {
-                    let message = "(\(Version.number)) Failed to register events: \(callResult)"
-                    Logger.shared.errorLog(message)
-                    completion(.failure(.unknown(message)))
-                    return
-                }
-                completion(.success((res, callResult)))
-            case .failure(let error):
-                let message = "(\(Version.number)) Failed to register events: \(error.localizedDescription)"
-                Logger.shared.errorLog(message)
-                completion(.failure(.unknown(message)))
-            }
+        let response: Bucketeer_Gateway_RegisterEventsResponse
+        let status: GRPCStatus
+        do {
+            let result = try call.response.and(call.status).wait()
+            response = result.0
+            status = result.1
+        } catch {
+            let message = "(\(Version.number)) Failed to register events: \(error.localizedDescription)"
+            Logger.shared.errorLog(message)
+            completion(.failure(.unknown(message)))
+            return
         }
+        let callResult = CallResult(success: status.isOk, code: status.code, message: status.message)
+        if callResult.isFailed {
+            let message = "(\(Version.number)) Failed to register events: \(callResult)"
+            Logger.shared.errorLog(message)
+            completion(.failure(.unknown(message)))
+            return
+        }
+        completion(.success((response, callResult)))
     }
 }

--- a/Bucketeer/Sources/APIClient.swift
+++ b/Bucketeer/Sources/APIClient.swift
@@ -13,7 +13,6 @@ protocol APIClientProtocol {
 final class APIClient: APIClientProtocol {
     private let config: Config
     private let serviceClient: Bucketeer_Gateway_GatewayClient
-    private let queue = DispatchQueue(label: "jp.co.cyberagent.bucketeer.APIQueue", attributes: .concurrent)
     
     init(config: Config) {
         self.config = config
@@ -26,53 +25,49 @@ final class APIClient: APIClientProtocol {
     }
     
     func getEvaluations(userEntity: UserEntity, userEvaluationsId: String, completion: @escaping (Result<(Bucketeer_Gateway_GetEvaluationsResponse?, CallResult), BucketeerError>) -> Void) {
-        queue.async {
-            var request = Bucketeer_Gateway_GetEvaluationsRequest()
-            request.user = userEntity.user
-            request.tag = self.config.tag
-            request.userEvaluationsID = userEvaluationsId
-            let call = self.serviceClient.getEvaluations(request)
-            call.response.and(call.status).whenComplete { result in
-                switch (result) {
-                case .success((let res, let status)):
-                    let callResult = CallResult(success: status.isOk, code: status.code, message: status.message)
-                    if callResult.isFailed {
-                        let message = "(\(Version.number)) Failed to get evaluations: \(callResult)"
-                        Logger.shared.errorLog(message)
-                        completion(.failure(.unknown(message)))
-                        return
-                    }
-                    completion(.success((res, callResult)))
-                case .failure(let error):
-                    let message = "(\(Version.number)) Failed to get evaluations: \(error.localizedDescription)"
+        var request = Bucketeer_Gateway_GetEvaluationsRequest()
+        request.user = userEntity.user
+        request.tag = self.config.tag
+        request.userEvaluationsID = userEvaluationsId
+        let call = self.serviceClient.getEvaluations(request)
+        call.response.and(call.status).whenComplete { result in
+            switch (result) {
+            case .success((let res, let status)):
+                let callResult = CallResult(success: status.isOk, code: status.code, message: status.message)
+                if callResult.isFailed {
+                    let message = "(\(Version.number)) Failed to get evaluations: \(callResult)"
                     Logger.shared.errorLog(message)
                     completion(.failure(.unknown(message)))
+                    return
                 }
+                completion(.success((res, callResult)))
+            case .failure(let error):
+                let message = "(\(Version.number)) Failed to get evaluations: \(error.localizedDescription)"
+                Logger.shared.errorLog(message)
+                completion(.failure(.unknown(message)))
             }
         }
     }
     
     func registerEvents(eventEntities: [EventEntity], completion: @escaping (Result<(Bucketeer_Gateway_RegisterEventsResponse?, CallResult), BucketeerError>) -> Void) {
-        queue.async {
-            var request = Bucketeer_Gateway_RegisterEventsRequest()
-            request.events = eventEntities.compactMap { try? Bucketeer_Event_Client_Event(serializedData: $0.data) }
-            let call = self.serviceClient.registerEvents(request)
-            call.response.and(call.status).whenComplete { result in
-                switch (result) {
-                case .success((let res, let status)):
-                    let callResult = CallResult(success: status.isOk, code: status.code, message: status.message)
-                    if callResult.isFailed {
-                        let message = "(\(Version.number)) Failed to register events: \(callResult)"
-                        Logger.shared.errorLog(message)
-                        completion(.failure(.unknown(message)))
-                        return
-                    }
-                    completion(.success((res, callResult)))
-                case .failure(let error):
-                    let message = "(\(Version.number)) Failed to register events: \(error.localizedDescription)"
+        var request = Bucketeer_Gateway_RegisterEventsRequest()
+        request.events = eventEntities.compactMap { try? Bucketeer_Event_Client_Event(serializedData: $0.data) }
+        let call = self.serviceClient.registerEvents(request)
+        call.response.and(call.status).whenComplete { result in
+            switch (result) {
+            case .success((let res, let status)):
+                let callResult = CallResult(success: status.isOk, code: status.code, message: status.message)
+                if callResult.isFailed {
+                    let message = "(\(Version.number)) Failed to register events: \(callResult)"
                     Logger.shared.errorLog(message)
                     completion(.failure(.unknown(message)))
+                    return
                 }
+                completion(.success((res, callResult)))
+            case .failure(let error):
+                let message = "(\(Version.number)) Failed to register events: \(error.localizedDescription)"
+                Logger.shared.errorLog(message)
+                completion(.failure(.unknown(message)))
             }
         }
     }

--- a/Bucketeer/Sources/BucketeerSDK.swift
+++ b/Bucketeer/Sources/BucketeerSDK.swift
@@ -10,34 +10,22 @@ import SwiftProtobuf
 /// https://bucketeer.io/docs/#/sdk-reference-guides-ios
 ///
 public final class BucketeerSDK {
-    private enum QueueLabels {
-        static let setUserQueueLabel = "jp.co.cyberagent.bucketeer.setUserQueue"
-        static let getVariationQueueLabel = "jp.co.cyberagent.bucketeer.getVariationQueue"
-        static let trackQueueLabel = "jp.co.cyberagent.bucketeer.trackQueue"
-        static let getEvaluationsQueueLabel = "jp.co.cyberagent.bucketeer.getEvaluationsQueue"
-        static let registerEventsQueueLabel = "jp.co.cyberagent.bucketeer.registerEventsQueue"
-    }
-    
     private static var _shared: BucketeerSDK?
     public static var shared: BucketeerSDK {
         return _shared ?? { fatalError("Failed to access shared instance. Need to Bucketeer.setup()") }()
     }
-    
-    private let setUserQueue = DispatchQueue(label: QueueLabels.setUserQueueLabel, attributes: .concurrent)
-    private let getVariationQueue = DispatchQueue(label: QueueLabels.getVariationQueueLabel, attributes: .concurrent)
-    private let trackQueue = DispatchQueue(label: QueueLabels.trackQueueLabel, attributes: .concurrent)
-    private let registerEventsQueue = DispatchQueue(label: QueueLabels.registerEventsQueueLabel)
-    
+
+    private let taskQueue = DispatchQueue(label: "jp.co.cyberagent.bucketeer.taskQueue")
     private let reachability = Reachability()!
     
     private lazy var getEvaluationsPoller: Poller = {
-        return Poller(interval: self.config.getEvaluationsPollingInterval, label: QueueLabels.getEvaluationsQueueLabel) {
+        return Poller(interval: self.config.getEvaluationsPollingInterval, queue: taskQueue) {
             self.getEvaluationsPollingEvent()
         }
     }()
     
     private lazy var registerEventsPoller: Poller = {
-        return Poller(interval: self.config.registerEventsPollingInterval, label: QueueLabels.registerEventsQueueLabel) {
+        return Poller(interval: self.config.registerEventsPollingInterval, queue: taskQueue) {
             self.registerEventsPollingEvent()
         }
     }()
@@ -153,7 +141,7 @@ public extension BucketeerSDK {
     }
     
     func syncEvaluations() {
-        return getEvaluationsPollingEvent()
+        return _syncEvaluations()
     }
     
     // MARK: Feature
@@ -195,55 +183,27 @@ public extension BucketeerSDK {
 
 private extension BucketeerSDK {
     // TODO: add cares about atomic data access: ex. call setUser while processing setUser could cause unintentional data state
-    func _setUser(userID: String, userAttributes: [String: String]? = nil, completion: ((Result<Void, BucketeerError>) -> Void)? = nil) {
-        guard let userEntity = UserEntity(id: userID, attributes: userAttributes) else {
-            let message = "(\(Version.number)) Failed to init userEntity instance"
-            Logger.shared.errorLog(message)
-            completion?(.failure(.unknown(message)))
-            return
-        }
-        self.userEntity = userEntity
-        setUserQueue.async {
-            self.latestEvaluationStore.fetchAll(userID: userID) { [weak self] result in
-                guard let me = self else {
-                    let message = "(\(Version.number)) Failed to refer self in setUserQueue"
-                    Logger.shared.errorLog(message)
-                    completion?(.failure(.unknown(message)))
-                    return
-                }
-                func startPolling() {
-                    me.startEvaluationsPolling()
-                    me.startRegisterEventsPolling()
-                }
-                switch result {
-                case .success:
-                    guard me.isOnline else {
-                        startPolling()
-                        let message = "Failed to setUser because the network connection was unavailable"
-                        completion?(.failure(.network(message)))
-                        return
-                    }
-                    let startTime = CFAbsoluteTimeGetCurrent()
-                    me.evaluationSynchronizer.syncEvaluations(userEntity: userEntity) { result in
-                        switch result {
-                        case .success(let response):
-                            let status = StatusKey(rawValue: response.state.rawValue)?.state ?? ""
-                            me._sendGetEvaluationLatencyMetricsEvent(duration: TimeInterval(CFAbsoluteTimeGetCurrent() - startTime), state: status)
-                            do {
-                                let size = try response.serializedData().count
-                                me._sendGetEvaluationSizeMetricsEvent(sizeByte: Int32(size), state: status)
-                            } catch {
-                                Logger.shared.errorLog("Unable to serialize evaluations: \(error.localizedDescription)")
-                            }
-                            completion?(.success(()))
-                        case .failure(let error):
-                            completion?(.failure(error))
-                        }
-                        startPolling()
-                    }
-                case .failure(let error):
-                    completion?(.failure(error))
-                }
+    func _setUser(
+        userID: String,
+        userAttributes: [String: String]? = nil,
+        completion: ((Result<Void, BucketeerError>) -> Void)? = nil)
+    {
+        taskQueue.async { [getEvaluationsPoller, registerEventsPoller, startEvaluationsPolling, startRegisterEventsPolling, _syncEvaluations] in
+            getEvaluationsPoller.stop()
+            registerEventsPoller.stop()
+            guard let userEntity = UserEntity(id: userID, attributes: userAttributes) else {
+                let message = "(\(Version.number)) Failed to init userEntity instance"
+                Logger.shared.errorLog(message)
+                startEvaluationsPolling()
+                startRegisterEventsPolling()
+                completion?(.failure(.unknown(message)))
+                return
+            }
+            self.userEntity = userEntity
+            _syncEvaluations() { result in
+                startEvaluationsPolling()
+                startRegisterEventsPolling()
+                completion?(result)
             }
         }
     }
@@ -264,21 +224,21 @@ private extension BucketeerSDK {
             return defaultValue
         }
         if let evaluationEntity = latestEvaluationStore.fetch(featureID: featureID) {
-            getVariationQueue.async { [currentEvaluationStore, eventSaver] in
+            taskQueue.async { [currentEvaluationStore, eventSaver, registerEventsIfNeeded] in
                 currentEvaluationStore.save([evaluationEntity])
-                eventSaver.saveEvaluationEvent(userEntity: userEntity, evaluationEntity: evaluationEntity, completion: self.registerEventsIfNeeded)
+                eventSaver.saveEvaluationEvent(userEntity: userEntity, evaluationEntity: evaluationEntity, completion: registerEventsIfNeeded)
             }
             return T.variationValue(evaluationEntity.evaluation.variation.value) ?? defaultValue
         }
         // if there is no matched latestEvaluation in local store, add a default value event to event store
-        getVariationQueue.async { [eventSaver] in
-            eventSaver.saveClientDefaultEvaluationEvent(userEntity: userEntity, featureID: featureID, completion: self.registerEventsIfNeeded)
+        taskQueue.async { [eventSaver, registerEventsIfNeeded] in
+            eventSaver.saveClientDefaultEvaluationEvent(userEntity: userEntity, featureID: featureID, completion: registerEventsIfNeeded)
         }
         return defaultValue
     }
     
     func _track(goalID: String, value: Double) {
-        trackQueue.async { [userEntity, currentEvaluationStore, eventSaver, registerEventsIfNeeded] in
+        taskQueue.async { [userEntity, currentEvaluationStore, eventSaver, registerEventsIfNeeded] in
             guard let userEntity = userEntity else {
                 return
             }
@@ -292,28 +252,7 @@ private extension BucketeerSDK {
         }
     }
     
-    func _sendGetEvaluationLatencyMetricsEvent(duration: TimeInterval, state: String) {
-        self.trackQueue.async { [duration] in
-            self.eventSaver.saveGetEvaluationLatencyMetricsEvent(
-                duration: duration,
-                labels: ["tag": self.config.tag, "state": state],
-                completion: self.registerEventsIfNeeded)
-        }
-    }
-    
-    func _sendGetEvaluationSizeMetricsEvent(sizeByte: Int32, state: String) {
-        self.trackQueue.async { [sizeByte] in
-            self.eventSaver.saveGetEvaluationSizeMetricsEvent(
-                sizeByte: sizeByte,
-                labels: ["tag": self.config.tag, "state": state],
-                completion: self.registerEventsIfNeeded)
-        }
-    }
-    
     func registerEventsIfNeeded(eventsCount: Int?) -> () {
-        guard isOnline else {
-            return
-        }
         if let eventsCount = eventsCount, eventsCount < config.minEventsPerRequest {
             return
         }
@@ -321,9 +260,13 @@ private extension BucketeerSDK {
     }
 
     func _registerEvents(completion: (() -> Void)? = nil) {
-        self.registerEventsQueue.sync {
+        taskQueue.async { [isOnline, config, eventStore, eventRegisterer] in
+            guard isOnline else {
+                completion?()
+                return
+            }
             eventStore.fetch(limit: config.maxEventsPerRequest) { eventEntities in
-                self.eventRegisterer.registerEvents(eventEntities: eventEntities) { _ in
+                eventRegisterer.registerEvents(eventEntities: eventEntities) { _ in
                     completion?()
                 }
             }
@@ -343,6 +286,52 @@ private extension BucketeerSDK {
         }
         return nil
     }
+
+    func _syncEvaluations(completion: ((Result<Void, BucketeerError>) -> Void)? = nil) {
+        taskQueue.async { [isOnline, userEntity, evaluationSynchronizer, _sendGetEvaluationLatencyMetricsEvent, _sendGetEvaluationSizeMetricsEvent] in
+            guard isOnline, let userEntity = userEntity else {
+                completion?(.success(()))
+                return
+            }
+            let startTime = CFAbsoluteTimeGetCurrent()
+            evaluationSynchronizer.syncEvaluations(userEntity: userEntity) { result in
+                switch result {
+                case .success(let response):
+                    let status = StatusKey(rawValue: response.state.rawValue)?.state ?? ""
+                    _sendGetEvaluationLatencyMetricsEvent(TimeInterval(CFAbsoluteTimeGetCurrent() - startTime), status)
+                    do {
+                        let size = try response.serializedData().count
+                        _sendGetEvaluationSizeMetricsEvent(Int32(size), status)
+                    } catch {
+                        Logger.shared.errorLog("Unable to serialize evaluations: \(error.localizedDescription)")
+                    }
+                    Logger.shared.debugLog("Succeeded to sync evaluations")
+                    completion?(.success(()))
+                case .failure(let error):
+                    Logger.shared.errorLog("Failed to sync evaluations: \(error.localizedDescription)")
+                    completion?(.failure(error))
+                }
+            }
+        }
+    }
+
+    func _sendGetEvaluationLatencyMetricsEvent(duration: TimeInterval, state: String) {
+        taskQueue.async { [eventSaver, config, registerEventsIfNeeded] in
+            eventSaver.saveGetEvaluationLatencyMetricsEvent(
+                duration: duration,
+                labels: ["tag": config.tag, "state": state],
+                completion: registerEventsIfNeeded)
+        }
+    }
+
+    func _sendGetEvaluationSizeMetricsEvent(sizeByte: Int32, state: String) {
+        taskQueue.async { [eventSaver, config, registerEventsIfNeeded] in
+            eventSaver.saveGetEvaluationSizeMetricsEvent(
+                sizeByte: sizeByte,
+                labels: ["tag": config.tag, "state": state],
+                completion: registerEventsIfNeeded)
+        }
+    }
 }
 
 // MARK: - Polling
@@ -350,38 +339,17 @@ private extension BucketeerSDK {
 private extension BucketeerSDK {
     func getEvaluationsPollingEvent() {
         Logger.shared.debugLog("getEvaluationsPollingEvent fired")
-        guard isOnline, let userEntity = userEntity else {
-            return
-        }
         getEvaluationsPoller.stop()
-        let startTime = CFAbsoluteTimeGetCurrent()
-        evaluationSynchronizer.syncEvaluations(userEntity: userEntity) { result in
-            switch result {
-            case .success(let response):
-                let status = StatusKey(rawValue: response.state.rawValue)?.state ?? ""
-                self._sendGetEvaluationLatencyMetricsEvent(duration: TimeInterval(CFAbsoluteTimeGetCurrent() - startTime), state: status)
-                do {
-                    let size = try response.serializedData().count
-                    self._sendGetEvaluationSizeMetricsEvent(sizeByte: Int32(size), state: status)
-                } catch {
-                    Logger.shared.errorLog("Unable to serialize evaluations: \(error.localizedDescription)")
-                }
-                Logger.shared.debugLog("Succeeded to sync evaluations")
-            case .failure(let error):
-                Logger.shared.errorLog("Failed to sync evaluations: \(error.localizedDescription)")
-            }
-            self.startEvaluationsPolling()
+        _syncEvaluations() { [startEvaluationsPolling] _ in
+            startEvaluationsPolling()
         }
     }
     
     func registerEventsPollingEvent() {
         Logger.shared.debugLog("registerEventsPollingEvent fired")
-        guard isOnline else {
-            return
-        }
         registerEventsPoller.stop()
-        self._registerEvents() {
-             self.startRegisterEventsPolling()
+        _registerEvents() { [startRegisterEventsPolling] in
+            startRegisterEventsPolling()
         }
     }
 }

--- a/Bucketeer/Sources/BucketeerSDK.swift
+++ b/Bucketeer/Sources/BucketeerSDK.swift
@@ -230,7 +230,7 @@ private extension BucketeerSDK {
             }
             return T.variationValue(evaluationEntity.evaluation.variation.value) ?? defaultValue
         }
-        // if there is no matched latestEvaluation in local store, add a default value event to event store
+        // if there is no evaluation for the target feature flag, report the evaluation event as default
         taskQueue.async { [eventSaver, registerEventsIfNeeded] in
             eventSaver.saveClientDefaultEvaluationEvent(userEntity: userEntity, featureID: featureID, completion: registerEventsIfNeeded)
         }

--- a/Bucketeer/Sources/EventRegisterer.swift
+++ b/Bucketeer/Sources/EventRegisterer.swift
@@ -6,31 +6,21 @@ class EventRegisterer {
     let apiClient: APIClientProtocol
     let eventStore: EventStore
     
-    // TODO: it's better to remove this flag because this type of variable leads bugs
-    private var isProcessing = false
-    
     init(apiClient: APIClientProtocol, eventStore: EventStore) {
         self.apiClient = apiClient
         self.eventStore = eventStore
     }
     
     func registerEvents(eventEntities: [EventEntity], completion: ((Result<CallResult?, BucketeerError>) -> Void)? = nil) {
-        guard !isProcessing else {
-            Logger.shared.debugLog("Skipped because another one is running")
-            completion?(.success(nil))
-            return
-        }
         guard !eventEntities.isEmpty else {
-            Logger.shared.debugLog("Skipped because of no events")
+            Logger.shared.debugLog("There are no events to register")
             completion?(.success(nil))
             return
         }
-        isProcessing = true
-        _registerEvents(eventEntities: eventEntities) { [weak self] result in
-            self?.isProcessing = false
+        _registerEvents(eventEntities: eventEntities) { result in
             switch result {
             case .success:
-                Logger.shared.debugLog("Succeeded to register events")
+                Logger.shared.debugLog("Succeeded to register the events")
             case .failure(let error):
                 Logger.shared.errorLog("Failed to register events: \(error.localizedDescription)")
             }

--- a/Bucketeer/Sources/EventStore.swift
+++ b/Bucketeer/Sources/EventStore.swift
@@ -17,116 +17,92 @@ class EventStore {
     }
 
     func fetch(limit: Int = 100, completion: @escaping ([EventEntity]) -> Void) {
-        db.run { [weak self] in
-            guard let me = self else {
-                completion([])
-                return
-            }
-            do {
-                let stmt = try me.db.prepareStatement(sql: Query.fetch)
-                try me.db.bindInt(stmt: stmt, name: ":limit", value: limit)
-                var items: [EventEntity] = []
-                while (try me.db.query(stmt: stmt) == SQLITE_ROW) {
-                    guard let id = sqlite3_column_text(stmt, 0),
-                        let type = sqlite3_column_text(stmt, 1) else {
-                            continue
-                    }
-                    let idStr = String(cString: id)
-                    let typeStr = String(cString: type)
-                    guard let eventType = EventEntity.EventType(rawValue: typeStr) else {
+        do {
+            let stmt = try db.prepareStatement(sql: Query.fetch)
+            try db.bindInt(stmt: stmt, name: ":limit", value: limit)
+            var items: [EventEntity] = []
+            while (try db.query(stmt: stmt) == SQLITE_ROW) {
+                guard let id = sqlite3_column_text(stmt, 0),
+                    let type = sqlite3_column_text(stmt, 1) else {
                         continue
-                    }
-                    let blob = sqlite3_column_blob(stmt, 2)
-                    let size = sqlite3_column_bytes(stmt, 2)
-                    let data = NSData(bytes: blob, length: Int(size)) as Data
-                    items.append(EventEntity(id: idStr, type: eventType, data: data))
                 }
-                try me.db.finalize(stmt: stmt)
-                completion(items)
-            } catch {
-                Logger.shared.errorLog("Failed to fetch Events: \(error.localizedDescription)")
-                completion([])
+                let idStr = String(cString: id)
+                let typeStr = String(cString: type)
+                guard let eventType = EventEntity.EventType(rawValue: typeStr) else {
+                    continue
+                }
+                let blob = sqlite3_column_blob(stmt, 2)
+                let size = sqlite3_column_bytes(stmt, 2)
+                let data = NSData(bytes: blob, length: Int(size)) as Data
+                items.append(EventEntity(id: idStr, type: eventType, data: data))
             }
+            try db.finalize(stmt: stmt)
+            completion(items)
+        } catch {
+            Logger.shared.errorLog("Failed to fetch Events: \(error.localizedDescription)")
+            completion([])
         }
     }
 
     func save(_ items: [EventEntity], completion: ((Int) -> Void)? = nil) {
-        db.run { [weak self] in
-            guard let me = self else {
-                completion?(0)
-                return
-            }
-            for item in items {
-                do {
-                    let stmt = try me.db.prepareStatement(sql: Query.save)
-                    try me.db.bindText(stmt: stmt, name: ":id", value: item.id)
-                    try me.db.bindText(stmt: stmt, name: ":type", value: item.type.rawValue)
-                    let bytes = [UInt8](item.data)
-                    if sqlite3_bind_blob(stmt, sqlite3_bind_parameter_index(stmt, ":data"), bytes, Int32(bytes.count), nil) != SQLITE_OK {
-                        continue
-                    }
-                    try me.db.execute(stmt: stmt)
-                    try me.db.finalize(stmt: stmt)
-                } catch {
-                    Logger.shared.errorLog("Failed to save Events: \(error.localizedDescription)")
-                    break
-                }
-            }
-            guard let countStmt = try? me.db.prepareStatement(sql: Query.fetchCount) else {
-                completion?(0)
-                return
-            }
-            var count = 0
+        for item in items {
             do {
-                if try me.db.query(stmt: countStmt) == SQLITE_ROW {
-                    count = Int(sqlite3_column_int(countStmt, 0))
+                let stmt = try db.prepareStatement(sql: Query.save)
+                try db.bindText(stmt: stmt, name: ":id", value: item.id)
+                try db.bindText(stmt: stmt, name: ":type", value: item.type.rawValue)
+                let bytes = [UInt8](item.data)
+                if sqlite3_bind_blob(stmt, sqlite3_bind_parameter_index(stmt, ":data"), bytes, Int32(bytes.count), nil) != SQLITE_OK {
+                    continue
                 }
-                try me.db.finalize(stmt: countStmt)
+                try db.execute(stmt: stmt)
+                try db.finalize(stmt: stmt)
             } catch {
-                Logger.shared.errorLog("Failed to get count of Events: \(error.localizedDescription)")
+                Logger.shared.errorLog("Failed to save Events: \(error.localizedDescription)")
+                break
             }
-            completion?(count)
         }
+        guard let countStmt = try? db.prepareStatement(sql: Query.fetchCount) else {
+            completion?(0)
+            return
+        }
+        var count = 0
+        do {
+            if try db.query(stmt: countStmt) == SQLITE_ROW {
+                count = Int(sqlite3_column_int(countStmt, 0))
+            }
+            try db.finalize(stmt: countStmt)
+        } catch {
+            Logger.shared.errorLog("Failed to get count of Events: \(error.localizedDescription)")
+        }
+        completion?(count)
     }
 
     func delete(_ items: [EventEntity], completion: (() -> Void)? = nil) {
-        db.run { [weak self] in
-            guard let me = self else {
-                completion?()
-                return
+        for item in items {
+            do {
+                let stmt = try db.prepareStatement(sql: Query.delete)
+                try db.bindText(stmt: stmt, name: ":id", value: item.id)
+                try db.execute(stmt: stmt)
+                try db.finalize(stmt: stmt)
+            } catch {
+                Logger.shared.errorLog("Failed to delete Events: \(error.localizedDescription)")
+                break
             }
-            for item in items {
-                do {
-                    let stmt = try me.db.prepareStatement(sql: Query.delete)
-                    try me.db.bindText(stmt: stmt, name: ":id", value: item.id)
-                    try me.db.execute(stmt: stmt)
-                    try me.db.finalize(stmt: stmt)
-                } catch {
-                    Logger.shared.errorLog("Failed to delete Events: \(error.localizedDescription)")
-                    break
-                }
-            }
-            completion?()
         }
+        completion?()
     }
 }
 
 extension EventStore {
     // for test
     func deleteAll(completion: (() -> Void)? = nil) {
-        db.run { [weak self] in
-            guard let me = self else {
-                completion?()
-                return
-            }
-            do {
-                let stmt = try me.db.prepareStatement(sql: Query.deleteAll)
-                try me.db.execute(stmt: stmt)
-                try me.db.finalize(stmt: stmt)
-            } catch {
-                Logger.shared.errorLog("Failed to delete Events: \(error.localizedDescription)")
-            }
-            completion?()
+        do {
+            let stmt = try db.prepareStatement(sql: Query.deleteAll)
+            try db.execute(stmt: stmt)
+            try db.finalize(stmt: stmt)
+        } catch {
+            Logger.shared.errorLog("Failed to delete Events: \(error.localizedDescription)")
         }
+        completion?()
     }
 }

--- a/Bucketeer/Sources/LatestEvaluationStore.swift
+++ b/Bucketeer/Sources/LatestEvaluationStore.swift
@@ -10,7 +10,6 @@ class LatestEvaluationStore {
         static let deleteAll = "DELETE FROM LatestEvaluations;"
     }
 
-    private let queue = DispatchQueue(label: "jp.co.cyberagent.Bucketeer.LatestEvaluationStore") // Serial
     private let db: SQLiteDatabase
     private(set) var evaluationEntities: Set<EvaluationEntity> = []
 
@@ -19,38 +18,30 @@ class LatestEvaluationStore {
     }
 
     func fetchAll(userID: String, completion: @escaping (Result<[EvaluationEntity], BucketeerError>) -> Void) {
-        db.run { [weak self] in
-            guard let me = self else {
-                let message = "(\(Version.number)) Failed to refer self"
-                Logger.shared.errorLog(message)
-                completion(.failure(.unknown(message)))
-                return
-            }
-            do {
-                let stmt = try me.db.prepareStatement(sql: Query.fetchAll)
-                try me.db.bindText(stmt: stmt, name: ":userID", value: userID)
-                var items: [EvaluationEntity] = []
-                while (try me.db.query(stmt: stmt) == SQLITE_ROW) {
-                    let blob = sqlite3_column_blob(stmt, 0)
-                    let size = sqlite3_column_bytes(stmt, 0)
-                    let data = NSData(bytes: blob, length: Int(size)) as Data
-                    do {
-                        let evaluation = try Bucketeer_Feature_Evaluation(serializedData: data)
-                        if let entity = EvaluationEntity(evaluation: evaluation) {
-                            items.append(entity)
-                        }
-                    } catch {
-                        Logger.shared.errorLog(error.localizedDescription)
+        do {
+            let stmt = try db.prepareStatement(sql: Query.fetchAll)
+            try db.bindText(stmt: stmt, name: ":userID", value: userID)
+            var items: [EvaluationEntity] = []
+            while (try db.query(stmt: stmt) == SQLITE_ROW) {
+                let blob = sqlite3_column_blob(stmt, 0)
+                let size = sqlite3_column_bytes(stmt, 0)
+                let data = NSData(bytes: blob, length: Int(size)) as Data
+                do {
+                    let evaluation = try Bucketeer_Feature_Evaluation(serializedData: data)
+                    if let entity = EvaluationEntity(evaluation: evaluation) {
+                        items.append(entity)
                     }
+                } catch {
+                    Logger.shared.errorLog(error.localizedDescription)
                 }
-                try me.db.finalize(stmt: stmt)
-                me.evaluationEntities = Set(items) // update in-memory data
-                completion(.success(items))
-            } catch {
-                let message = "(\(Version.number)) Failed to fetchAll LatestEvaluations: \(error.localizedDescription)"
-                Logger.shared.errorLog(message)
-                completion(.failure(.unknown(message)))
             }
+            try db.finalize(stmt: stmt)
+            evaluationEntities = Set(items) // update in-memory data
+            completion(.success(items))
+        } catch {
+            let message = "(\(Version.number)) Failed to fetchAll LatestEvaluations: \(error.localizedDescription)"
+            Logger.shared.errorLog(message)
+            completion(.failure(.unknown(message)))
         }
     }
 
@@ -60,93 +51,74 @@ class LatestEvaluationStore {
 
     func replaceAll(userID: String, entities: Set<EvaluationEntity>, completion: @escaping (Result<Void, BucketeerError>) -> Void) {
         evaluationEntities = entities // update in-memory data
-        db.run { [weak self] in
-            guard let me = self else {
-                let message = "(\(Version.number)) Failed to refer self while trying to replace all latest evaluations"
-                completion(.failure(.unknown(message)))
-                return
-            }
             // 1. delete target user's data
+        do {
+            let deleteStmt = try db.prepareStatement(sql: Query.delete)
+            try db.bindText(stmt: deleteStmt, name: ":userID", value: userID)
+            try db.execute(stmt: deleteStmt)
+            try db.finalize(stmt: deleteStmt)
+        } catch {
+            let message = "Failed to replaceAll LatestEvaluations: \(error.localizedDescription)"
+            Logger.shared.errorLog(message)
+            completion(.failure(.unknown(message)))
+            return
+        }
+        // 2. insert data
+        for item in entities {
             do {
-                let deleteStmt = try me.db.prepareStatement(sql: Query.delete)
-                try me.db.bindText(stmt: deleteStmt, name: ":userID", value: userID)
-                try me.db.execute(stmt: deleteStmt)
-                try me.db.finalize(stmt: deleteStmt)
+                let stmt = try db.prepareStatement(sql: Query.insert)
+                try db.bindText(stmt: stmt, name: ":id", value: item.id)
+                try db.bindText(stmt: stmt, name: ":userID", value: item.userID)
+                try db.bindText(stmt: stmt, name: ":featureID", value: item.featureID)
+                let bytes = [UInt8](item.data)
+                if sqlite3_bind_blob(stmt, sqlite3_bind_parameter_index(stmt, ":data"), bytes, Int32(bytes.count), nil) != SQLITE_OK {
+                    continue
+                }
+                try db.execute(stmt: stmt)
+                try db.finalize(stmt: stmt)
             } catch {
                 let message = "Failed to replaceAll LatestEvaluations: \(error.localizedDescription)"
                 Logger.shared.errorLog(message)
                 completion(.failure(.unknown(message)))
-                return
+                break
             }
-            // 2. insert data
-            for item in entities {
-                do {
-                    let stmt = try me.db.prepareStatement(sql: Query.insert)
-                    try me.db.bindText(stmt: stmt, name: ":id", value: item.id)
-                    try me.db.bindText(stmt: stmt, name: ":userID", value: item.userID)
-                    try me.db.bindText(stmt: stmt, name: ":featureID", value: item.featureID)
-                    let bytes = [UInt8](item.data)
-                    if sqlite3_bind_blob(stmt, sqlite3_bind_parameter_index(stmt, ":data"), bytes, Int32(bytes.count), nil) != SQLITE_OK {
-                        continue
-                    }
-                    try me.db.execute(stmt: stmt)
-                    try me.db.finalize(stmt: stmt)
-                } catch {
-                    let message = "Failed to replaceAll LatestEvaluations: \(error.localizedDescription)"
-                    Logger.shared.errorLog(message)
-                    completion(.failure(.unknown(message)))
-                    break
-                }
-            }
-            completion(.success(()))
         }
+        completion(.success(()))
     }
 
     func replacePartial(entities: Set<EvaluationEntity>, completion: (() -> Void)? = nil) {
         entities.forEach { evaluationEntities.update(with: $0) } // update in-memory data
-        db.run { [weak self] in
-            guard let me = self else {
-                completion?()
-                return
-            }
-            for item in entities {
-                do {
-                    let stmt = try me.db.prepareStatement(sql: Query.insertOrReplace)
-                    try me.db.bindText(stmt: stmt, name: ":id", value: item.id)
-                    try me.db.bindText(stmt: stmt, name: ":userID", value: item.userID)
-                    try me.db.bindText(stmt: stmt, name: ":featureID", value: item.featureID)
-                    let bytes = [UInt8](item.data)
-                    if sqlite3_bind_blob(stmt, sqlite3_bind_parameter_index(stmt, ":data"), bytes, Int32(bytes.count), nil) != SQLITE_OK {
-                        continue
-                    }
-                    try me.db.execute(stmt: stmt)
-                    try me.db.finalize(stmt: stmt)
-                } catch {
-                    Logger.shared.errorLog("Failed to replacePartial LatestEvaluations: \(error.localizedDescription)")
+        for item in entities {
+            do {
+                let stmt = try db.prepareStatement(sql: Query.insertOrReplace)
+                try db.bindText(stmt: stmt, name: ":id", value: item.id)
+                try db.bindText(stmt: stmt, name: ":userID", value: item.userID)
+                try db.bindText(stmt: stmt, name: ":featureID", value: item.featureID)
+                let bytes = [UInt8](item.data)
+                if sqlite3_bind_blob(stmt, sqlite3_bind_parameter_index(stmt, ":data"), bytes, Int32(bytes.count), nil) != SQLITE_OK {
+                    continue
                 }
+                try db.execute(stmt: stmt)
+                try db.finalize(stmt: stmt)
+            } catch {
+                Logger.shared.errorLog("Failed to replacePartial LatestEvaluations: \(error.localizedDescription)")
             }
-            completion?()
         }
+        completion?()
     }
 }
 
 extension LatestEvaluationStore {
     // for test
     func deleteAll(completion: (() -> Void)? = nil) {
-        evaluationEntities.removeAll() // update in-memory data
-        db.run { [weak self] in
-            guard let me = self else {
-                completion?()
-                return
-            }
-            do {
-                let stmt = try me.db.prepareStatement(sql: Query.deleteAll)
-                try me.db.execute(stmt: stmt)
-                try me.db.finalize(stmt: stmt)
-            } catch {
-                Logger.shared.errorLog("Failed to delete LatestEvaluations: \(error.localizedDescription)")
-            }
-            completion?()
+    evaluationEntities.removeAll() // update in-memory data
+        do {
+            let stmt = try db.prepareStatement(sql: Query.deleteAll)
+            try db.execute(stmt: stmt)
+            try db.finalize(stmt: stmt)
+        } catch {
+            Logger.shared.errorLog("Failed to delete LatestEvaluations: \(error.localizedDescription)")
         }
+        completion?()
     }
 }

--- a/Bucketeer/Sources/Poller.swift
+++ b/Bucketeer/Sources/Poller.swift
@@ -2,23 +2,21 @@ import Foundation
 
 class Poller {
     private var timer: DispatchSourceTimer?
-
     private let interval: TimeInterval
-    private let label: String
+    private let queue: DispatchQueue
     private let handler: (() -> Void)
 
-    init(interval: TimeInterval, label: String, handler: @escaping () -> Void) {
+    init(interval: TimeInterval, queue: DispatchQueue, handler: @escaping () -> Void) {
         self.interval = interval
-        self.label = label
         self.handler = handler
+        self.queue = queue
     }
 
     func start() {
         if timer != nil {
             return
         }
-        let queue = DispatchQueue(label: label)
-        timer = DispatchSource.makeTimerSource(queue: queue)
+        timer = DispatchSource.makeTimerSource(queue: self.queue)
         // memo: deadline is based on nanoseconds
         timer?.schedule(deadline: .now() + (interval / 1000), repeating: .milliseconds(Int(interval)))
         timer?.setEventHandler(handler: handler)
@@ -26,9 +24,6 @@ class Poller {
     }
 
     func stop() {
-        if timer == nil {
-            return
-        }
         timer?.cancel()
         timer = nil
     }

--- a/BucketeerTests/Sources/Unit/PollerTest.swift
+++ b/BucketeerTests/Sources/Unit/PollerTest.swift
@@ -8,9 +8,10 @@ class PollerTests: XCTestCase {
 
     func testStart() {
         let asyncExpectation = expectation(description: "")
+        let queue = DispatchQueue(label: "queue-test")
 
         var counter = 0
-        let poller = Poller(interval: 1000, label: "p001") {
+        let poller = Poller(interval: 1000, queue: queue) {
             print("pollingEvent called")
             counter += 1
         }
@@ -28,9 +29,10 @@ class PollerTests: XCTestCase {
 
     func testReset() {
         let asyncExpectation = expectation(description: "")
+        let queue = DispatchQueue(label: "queue-test")
 
         var counter = 0
-        let poller = Poller(interval: 1000, label: "p001") {
+        let poller = Poller(interval: 1000, queue: queue) {
             print("pollingEvent called")
             counter += 1
         }
@@ -55,9 +57,10 @@ class PollerTests: XCTestCase {
 
     func testStartRepeats() {
         let asyncExpectation = expectation(description: "")
+        let queue = DispatchQueue(label: "queue-test")
 
         var counter = 0
-        let poller = Poller(interval: 1000, label: "p001") {
+        let poller = Poller(interval: 1000, queue: queue) {
             print("pollingEvent called")
             counter += 1
         }
@@ -76,9 +79,10 @@ class PollerTests: XCTestCase {
 
     func testStopRepeats() {
         let asyncExpectation = expectation(description: "")
+        let queue = DispatchQueue(label: "queue-test")
 
         var counter = 0
-        let poller = Poller(interval: 1000, label: "p001") {
+        let poller = Poller(interval: 1000, queue: queue) {
             print("pollingEvent called")
             counter += 1
         }


### PR DESCRIPTION
To improve the thread resources and solve the non-thread-safe issue in the register events implementation, I changed the SDK to use one private queue and serialize all tasks.

Related to https://github.com/ca-dp/bucketeer/issues/1422