### PR TITLE
Fix changes

### DIFF
--- a/Bucketeer.xcodeproj/project.pbxproj
+++ b/Bucketeer.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		0065C3C628C7BB76002D92A2 /* Bucketeer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0065C3BE28C7BB76002D92A2 /* Bucketeer.framework */; };
 		0065C3CB28C7BB76002D92A2 /* BucketeerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C3CA28C7BB76002D92A2 /* BucketeerTests.swift */; };
 		0065C3CC28C7BB76002D92A2 /* Bucketeer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0065C3C028C7BB76002D92A2 /* Bucketeer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0065C3DB28C7BCC0002D92A2 /* Duration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C3DA28C7BCC0002D92A2 /* Duration.swift */; };
 		0065C3DD28C7BCFF002D92A2 /* Evaluation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C3DC28C7BCFF002D92A2 /* Evaluation.swift */; };
 		0065C3DF28C7BD32002D92A2 /* Variation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C3DE28C7BD32002D92A2 /* Variation.swift */; };
 		0065C3E128C7BD4E002D92A2 /* Reason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C3E028C7BD4E002D92A2 /* Reason.swift */; };
@@ -182,7 +181,6 @@
 		0065C3C028C7BB76002D92A2 /* Bucketeer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Bucketeer.h; sourceTree = "<group>"; };
 		0065C3C528C7BB76002D92A2 /* BucketeerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BucketeerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0065C3CA28C7BB76002D92A2 /* BucketeerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketeerTests.swift; sourceTree = "<group>"; };
-		0065C3DA28C7BCC0002D92A2 /* Duration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Duration.swift; sourceTree = "<group>"; };
 		0065C3DC28C7BCFF002D92A2 /* Evaluation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Evaluation.swift; sourceTree = "<group>"; };
 		0065C3DE28C7BD32002D92A2 /* Variation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variation.swift; sourceTree = "<group>"; };
 		0065C3E028C7BD4E002D92A2 /* Reason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reason.swift; sourceTree = "<group>"; };
@@ -416,7 +414,6 @@
 			isa = PBXGroup;
 			children = (
 				0047BDFE29796B8D00982361 /* ApiId.swift */,
-				0065C3DA28C7BCC0002D92A2 /* Duration.swift */,
 				0065C3DC28C7BCFF002D92A2 /* Evaluation.swift */,
 				0065C3E228C8136D002D92A2 /* Event.swift */,
 				0065C3E428C813D6002D92A2 /* EventData.swift */,
@@ -925,7 +922,6 @@
 				9340CA6028E1F2D400E690CC /* DataModule.swift in Sources */,
 				006E85CA28DED75500B5D90D /* Defaults.swift in Sources */,
 				9353AB3E29585A980093D1F8 /* Device.swift in Sources */,
-				0065C3DB28C7BCC0002D92A2 /* Duration.swift in Sources */,
 				006E85B728DEAF1400B5D90D /* ErrorResponse.swift in Sources */,
 				0065C3DD28C7BCFF002D92A2 /* Evaluation.swift in Sources */,
 				004B15FB290FBF79007F5357 /* EvaluationBackgroundTask.swift in Sources */,

--- a/Bucketeer/Sources/Internal/DI/Component.swift
+++ b/Bucketeer/Sources/Internal/DI/Component.swift
@@ -19,7 +19,7 @@ final class ComponentImpl: Component {
             evaluationDao: dataModule.evaluationDao,
             defaults: dataModule.defaults,
             idGenerator: dataModule.idGenerator,
-            config: dataModule.config
+            featureTag: dataModule.config.featureTag
         )
         self.eventInteractor = EventInteractorImpl(
             sdkVersion: dataModule.config.sdkVersion,

--- a/Bucketeer/Sources/Internal/DI/Component.swift
+++ b/Bucketeer/Sources/Internal/DI/Component.swift
@@ -18,7 +18,8 @@ final class ComponentImpl: Component {
             apiClient: dataModule.apiClient,
             evaluationDao: dataModule.evaluationDao,
             defaults: dataModule.defaults,
-            idGenerator: dataModule.idGenerator
+            idGenerator: dataModule.idGenerator,
+            config: dataModule.config
         )
         self.eventInteractor = EventInteractorImpl(
             sdkVersion: dataModule.config.sdkVersion,

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationInteractor.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationInteractor.swift
@@ -4,6 +4,8 @@ protocol EvaluationInteractor {
     func fetch(user: User, timeoutMillis: Int64?, completion: ((GetEvaluationsResult) -> Void)?)
     func getLatest(userId: String, featureId: String) -> Evaluation?
     func refreshCache(userId: String) throws
+    var currentEvaluationsId: String { get }
+    func resetCurrentEvaluationsId()
     @discardableResult
     func addUpdateListener(listener: EvaluationUpdateListener) -> String
     func removeUpdateListener(key: String)
@@ -90,6 +92,10 @@ final class EvaluationInteractorImpl: EvaluationInteractor {
 
     func refreshCache(userId: String) throws {
         evaluations[userId] = try evaluationDao.get(userId: userId)
+    }
+
+    func resetCurrentEvaluationsId() {
+        currentEvaluationsId = ""
     }
 
     func getLatest(userId: String, featureId: String) -> Evaluation? {

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationInteractor.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationInteractor.swift
@@ -26,13 +26,15 @@ final class EvaluationInteractorImpl: EvaluationInteractor {
     let evaluationDao: EvaluationDao
     let defaults: Defaults
     let idGenerator: IdGenerator
+    let config: BKTConfig
     let logger: Logger?
 
-    init(apiClient: ApiClient, evaluationDao: EvaluationDao, defaults: Defaults, idGenerator: IdGenerator, logger: Logger? = nil) {
+    init(apiClient: ApiClient, evaluationDao: EvaluationDao, defaults: Defaults, idGenerator: IdGenerator, config: BKTConfig, logger: Logger? = nil) {
         self.apiClient = apiClient
         self.evaluationDao = evaluationDao
         self.defaults = defaults
         self.idGenerator = idGenerator
+        self.config = config
         self.logger = logger
     }
 
@@ -52,6 +54,7 @@ final class EvaluationInteractorImpl: EvaluationInteractor {
         let currentEvaluationsId = self.currentEvaluationsId
         let evaluationDao = self.evaluationDao
         let logger = self.logger
+        let featureTag = self.config.featureTag
         apiClient.getEvaluations(
             user: user,
             userEvaluationsId: currentEvaluationsId,
@@ -69,7 +72,7 @@ final class EvaluationInteractorImpl: EvaluationInteractor {
                         try evaluationDao.deleteAllAndInsert(userId: user.id, evaluations: newEvaluations)
                     } catch let error {
                         logger?.error(error)
-                        completion?(result)
+                        completion?(.failure(error: .init(error: error), featureTag: featureTag))
                         return
                     }
                     self?.currentEvaluationsId = newEvaluationsId

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationInteractor.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationInteractor.swift
@@ -5,7 +5,7 @@ protocol EvaluationInteractor {
     func getLatest(userId: String, featureId: String) -> Evaluation?
     func refreshCache(userId: String) throws
     var currentEvaluationsId: String { get }
-    func resetCurrentEvaluationsId()
+    func clearCurrentEvaluationsId()
     @discardableResult
     func addUpdateListener(listener: EvaluationUpdateListener) -> String
     func removeUpdateListener(key: String)
@@ -94,7 +94,7 @@ final class EvaluationInteractorImpl: EvaluationInteractor {
         evaluations[userId] = try evaluationDao.get(userId: userId)
     }
 
-    func resetCurrentEvaluationsId() {
+    func clearCurrentEvaluationsId() {
         currentEvaluationsId = ""
     }
 

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationInteractor.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationInteractor.swift
@@ -26,15 +26,15 @@ final class EvaluationInteractorImpl: EvaluationInteractor {
     let evaluationDao: EvaluationDao
     let defaults: Defaults
     let idGenerator: IdGenerator
-    let config: BKTConfig
+    let featureTag: String
     let logger: Logger?
 
-    init(apiClient: ApiClient, evaluationDao: EvaluationDao, defaults: Defaults, idGenerator: IdGenerator, config: BKTConfig, logger: Logger? = nil) {
+    init(apiClient: ApiClient, evaluationDao: EvaluationDao, defaults: Defaults, idGenerator: IdGenerator, featureTag: String, logger: Logger? = nil) {
         self.apiClient = apiClient
         self.evaluationDao = evaluationDao
         self.defaults = defaults
         self.idGenerator = idGenerator
-        self.config = config
+        self.featureTag = featureTag
         self.logger = logger
     }
 
@@ -54,7 +54,7 @@ final class EvaluationInteractorImpl: EvaluationInteractor {
         let currentEvaluationsId = self.currentEvaluationsId
         let evaluationDao = self.evaluationDao
         let logger = self.logger
-        let featureTag = self.config.featureTag
+        let featureTag = self.featureTag
         apiClient.getEvaluations(
             user: user,
             userEvaluationsId: currentEvaluationsId,

--- a/Bucketeer/Sources/Internal/Event/EventDaoImpl.swift
+++ b/Bucketeer/Sources/Internal/Event/EventDaoImpl.swift
@@ -11,9 +11,11 @@ final class EventDaoImpl: EventDao {
     }
 
     func add(events: [Event]) throws {
-        let entities = try events.map {
-            try EventEntity(model: $0)
-        }
+        let storedEvents = try getEvents()
+        let storedEventHashSet = Set(storedEvents.map(\.eventHash))
+        let entities = try events
+            .filter { !storedEventHashSet.contains($0.eventHash) }
+            .map { try EventEntity(model: $0) }
         try db.insert(entities)
     }
 
@@ -23,5 +25,11 @@ final class EventDaoImpl: EventDao {
 
     func delete(ids: [String]) throws {
         try db.delete(EventEntity(), condition: .in(column: "id", values: ids))
+    }
+}
+
+private extension Event {
+    var eventHash: Int {
+        return self.event.hashValue
     }
 }

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -122,12 +122,12 @@ final class EventInteractorImpl: EventInteractor {
                     id: idGenerator.id(),
                     event: .metrics(.init(
                         timestamp: clock.currentTimeSeconds,
-                        event: .getEvaluationLatency(.init(
+                        event: .responseLatency(.init(
                             apiId: .getEvaluations,
                             labels: ["tag": featureTag],
                             latencySecond: .init(seconds)
                         )),
-                        type: .getEvaluationLatency,
+                        type: .responseLatency,
                         sdk_version: sdkVersion,
                         metadata: metadata
                     )),

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -162,6 +162,21 @@ final class EventInteractorImpl: EventInteractor {
         case .network:
             metricsEventData = .networkError(.init(apiId: .getEvaluations, labels: ["tag": featureTag]))
             metricsEventType = .networkError
+        case .badRequest:
+            metricsEventData = .badRequestError(.init(apiId: .getEvaluations, labels: ["tag": featureTag]))
+            metricsEventType = .badRequestError
+        case .unauthorized:
+            metricsEventData = .unauthorizedError(.init(apiId: .getEvaluations, labels: ["tag": featureTag]))
+            metricsEventType = .unauthorizedError
+        case .forbidden:
+            metricsEventData = .forbiddenError(.init(apiId: .getEvaluations, labels: ["tag": featureTag]))
+            metricsEventType = .forbiddenError
+        case .apiServer:
+            metricsEventData = .internalServerError(.init(apiId: .getEvaluations, labels: ["tag": featureTag]))
+            metricsEventType = .internalServerError
+        case .unknown:
+            metricsEventData = .unknownError(.init(apiId: .getEvaluations, labels: ["tag": featureTag]))
+            metricsEventType = .unknownError
         default:
             metricsEventData = .internalSdkError(.init(apiId: .getEvaluations, labels: ["tag": featureTag]))
             metricsEventType = .internalError

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -5,7 +5,7 @@ protocol EventInteractor {
     func trackEvaluationEvent(featureTag: String, user: User, evaluation: Evaluation) throws
     func trackDefaultEvaluationEvent(featureTag: String, user: User, featureId: String) throws
     func trackGoalEvent(featureTag: String, user: User, goalId: String, value: Double) throws
-    func trackFetchEvaluationsSuccess(featureTag: String, seconds: Float64, sizeByte: Int64) throws
+    func trackFetchEvaluationsSuccess(featureTag: String, seconds: Double, sizeByte: Int64) throws
     func trackFetchEvaluationsFailure(featureTag: String, error: BKTError) throws
     func trackRegisterEventsFailure(error: BKTError) throws
     func sendEvents(force: Bool, completion: ((Result<Bool, BKTError>) -> Void)?)
@@ -115,7 +115,7 @@ final class EventInteractorImpl: EventInteractor {
         updateEventsAndNotify()
     }
 
-    func trackFetchEvaluationsSuccess(featureTag: String, seconds: Float64, sizeByte: Int64) throws {
+    func trackFetchEvaluationsSuccess(featureTag: String, seconds: Double, sizeByte: Int64) throws {
         try eventDao.add(
             events: [
                 .init(

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -128,6 +128,7 @@ final class EventInteractorImpl: EventInteractor {
                             latencySecond: .init(seconds)
                         )),
                         type: .responseLatency,
+                        sourceId: .ios,
                         sdk_version: sdkVersion,
                         metadata: metadata
                     )),
@@ -143,6 +144,7 @@ final class EventInteractorImpl: EventInteractor {
                             size_byte: sizeByte
                         )),
                         type: .responseSize,
+                        sourceId: .ios,
                         sdk_version: sdkVersion,
                         metadata: metadata
                     )),
@@ -265,6 +267,7 @@ final class EventInteractorImpl: EventInteractor {
             timestamp: clock.currentTimeSeconds,
             event: metricsEventData,
             type: metricsEventType,
+            sourceId: .ios,
             sdk_version: sdkVersion,
             metadata: metadata
         ))

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -137,12 +137,12 @@ final class EventInteractorImpl: EventInteractor {
                     id: idGenerator.id(),
                     event: .metrics(.init(
                         timestamp: clock.currentTimeSeconds,
-                        event: .getEvaluationSize(.init(
+                        event: .responseSize(.init(
                             apiId: .getEvaluations,
                             labels: ["tag": featureTag],
                             size_byte: sizeByte
                         )),
-                        type: .getEvaluationSize,
+                        type: .responseSize,
                         sdk_version: sdkVersion,
                         metadata: metadata
                     )),

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -125,7 +125,7 @@ final class EventInteractorImpl: EventInteractor {
                         event: .getEvaluationLatency(.init(
                             apiId: .getEvaluations,
                             labels: ["tag": featureTag],
-                            duration: .init(seconds: seconds)
+                            duration: .init(seconds)
                         )),
                         type: .getEvaluationLatency,
                         sdk_version: sdkVersion,

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -256,7 +256,7 @@ final class EventInteractorImpl: EventInteractor {
         case .apiServer:
             metricsEventData = .internalServerError(.init(apiId: apiId, labels: labels))
             metricsEventType = .internalServerError
-        case .unknown:
+        case .unknownServer:
             metricsEventData = .unknownError(.init(apiId: apiId, labels: labels))
             metricsEventType = .unknownError
         default:

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -242,6 +242,15 @@ final class EventInteractorImpl: EventInteractor {
         case .forbidden:
             metricsEventData = .forbiddenError(.init(apiId: apiId, labels: labels))
             metricsEventType = .forbiddenError
+        case .notFound:
+            metricsEventData = .notFoundError(.init(apiId: apiId, labels: labels))
+            metricsEventType = .notFoundError
+        case .clientClosed:
+            metricsEventData = .clientClosedError(.init(apiId: apiId, labels: labels))
+            metricsEventType = .clientClosedError
+        case .unavailable:
+            metricsEventData = .unavailableError(.init(apiId: apiId, labels: labels))
+            metricsEventType = .unavailableError
         case .apiServer:
             metricsEventData = .internalServerError(.init(apiId: apiId, labels: labels))
             metricsEventType = .internalServerError

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -125,7 +125,7 @@ final class EventInteractorImpl: EventInteractor {
                         event: .getEvaluationLatency(.init(
                             apiId: .getEvaluations,
                             labels: ["tag": featureTag],
-                            duration: .init(seconds)
+                            latencySecond: .init(seconds)
                         )),
                         type: .getEvaluationLatency,
                         sdk_version: sdkVersion,

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -5,7 +5,7 @@ protocol EventInteractor {
     func trackEvaluationEvent(featureTag: String, user: User, evaluation: Evaluation) throws
     func trackDefaultEvaluationEvent(featureTag: String, user: User, featureId: String) throws
     func trackGoalEvent(featureTag: String, user: User, goalId: String, value: Double) throws
-    func trackFetchEvaluationsSuccess(featureTag: String, seconds: Int64, sizeByte: Int64) throws
+    func trackFetchEvaluationsSuccess(featureTag: String, seconds: Float64, sizeByte: Int64) throws
     func trackFetchEvaluationsFailure(featureTag: String, error: BKTError) throws
     func trackRegisterEventsFailure(error: BKTError) throws
     func sendEvents(force: Bool, completion: ((Result<Bool, BKTError>) -> Void)?)
@@ -115,7 +115,7 @@ final class EventInteractorImpl: EventInteractor {
         updateEventsAndNotify()
     }
 
-    func trackFetchEvaluationsSuccess(featureTag: String, seconds: Int64, sizeByte: Int64) throws {
+    func trackFetchEvaluationsSuccess(featureTag: String, seconds: Float64, sizeByte: Int64) throws {
         try eventDao.add(
             events: [
                 .init(
@@ -125,7 +125,7 @@ final class EventInteractorImpl: EventInteractor {
                         event: .responseLatency(.init(
                             apiId: .getEvaluations,
                             labels: ["tag": featureTag],
-                            latencySecond: .init(seconds)
+                            latencySecond: seconds
                         )),
                         type: .responseLatency,
                         sourceId: .ios,

--- a/Bucketeer/Sources/Internal/Model/Duration.swift
+++ b/Bucketeer/Sources/Internal/Model/Duration.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-struct Duration: Codable, Hashable {
-    let seconds: Int64
-}

--- a/Bucketeer/Sources/Internal/Model/EventData.swift
+++ b/Bucketeer/Sources/Internal/Model/EventData.swift
@@ -37,6 +37,7 @@ enum EventData: Hashable {
         let timestamp: Int64
         let event: MetricsEventData
         let type: MetricsEventType
+        let sourceId: SourceID
         var sdkVersion: String? = nil
         var metadata: [String: String]? = nil
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.MetricsEvent"
@@ -45,15 +46,17 @@ enum EventData: Hashable {
             case timestamp
             case event
             case type
+            case sourceId
             case sdkVersion
             case metadata
             case protobufType
         }
 
-        init(timestamp: Int64, event: MetricsEventData, type: MetricsEventType, sdk_version: String, metadata: [String: String]?) {
+        init(timestamp: Int64, event: MetricsEventData, type: MetricsEventType, sourceId: SourceID, sdk_version: String, metadata: [String: String]?) {
             self.timestamp = timestamp
             self.event = event
             self.type = type
+            self.sourceId = sourceId
             self.sdkVersion = sdk_version
             self.metadata = metadata
         }
@@ -63,6 +66,7 @@ enum EventData: Hashable {
             self.timestamp = try container.decode(Int64.self, forKey: .timestamp)
             self.type = try container.decode(MetricsEventType.self, forKey: .type)
             self.sdkVersion = try container.decodeIfPresent(String.self, forKey: .sdkVersion)
+            self.sourceId = try container.decode(SourceID.self, forKey: .sourceId)
             self.metadata = try container.decodeIfPresent([String: String].self, forKey: .metadata)
             switch self.type {
             case .responseLatency:
@@ -111,6 +115,7 @@ enum EventData: Hashable {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(timestamp, forKey: .timestamp)
             try container.encode(type, forKey: .type)
+            try container.encode(sourceId, forKey: .sourceId)
             if let sdkVersion {
                 try container.encode(sdkVersion, forKey: .sdkVersion)
             }

--- a/Bucketeer/Sources/Internal/Model/EventData.swift
+++ b/Bucketeer/Sources/Internal/Model/EventData.swift
@@ -77,9 +77,24 @@ enum EventData: Hashable {
             case .networkError:
                 let data = try container.decode(MetricsEventData.NetworkError.self, forKey: .event)
                 self.event = .networkError(data)
+            case .badRequestError:
+                let data = try container.decode(MetricsEventData.BadRequestError.self, forKey: .event)
+                self.event = .badRequestError(data)
+            case .unauthorizedError:
+                let data = try container.decode(MetricsEventData.UnauthorizedError.self, forKey: .event)
+                self.event = .unauthorizedError(data)
+            case .forbiddenError:
+                let data = try container.decode(MetricsEventData.ForbiddenError.self, forKey: .event)
+                self.event = .forbiddenError(data)
             case .internalError:
                 let data = try container.decode(MetricsEventData.InternalSdkError.self, forKey: .event)
                 self.event = .internalSdkError(data)
+            case .internalServerError:
+                let data = try container.decode(MetricsEventData.InternalServerError.self, forKey: .event)
+                self.event = .internalServerError(data)
+            case .unknownError:
+                let data = try container.decode(MetricsEventData.UnknownError.self, forKey: .event)
+                self.event = .unknownError(data)
             }
         }
 
@@ -100,7 +115,17 @@ enum EventData: Hashable {
                 try container.encode(eventData, forKey: .event)
             case .networkError(let eventData):
                 try container.encode(eventData, forKey: .event)
+            case .badRequestError(let eventData):
+                try container.encode(eventData, forKey: .event)
+            case .unauthorizedError(let eventData):
+                try container.encode(eventData, forKey: .event)
+            case .forbiddenError(let eventData):
+                try container.encode(eventData, forKey: .event)
             case .internalSdkError(let eventData):
+                try container.encode(eventData, forKey: .event)
+            case .internalServerError(let eventData):
+                try container.encode(eventData, forKey: .event)
+            case .unknownError(let eventData):
                 try container.encode(eventData, forKey: .event)
             }
             if let protobufType {

--- a/Bucketeer/Sources/Internal/Model/EventData.swift
+++ b/Bucketeer/Sources/Internal/Model/EventData.swift
@@ -65,9 +65,9 @@ enum EventData: Hashable {
             self.sdkVersion = try container.decodeIfPresent(String.self, forKey: .sdkVersion)
             self.metadata = try container.decodeIfPresent([String: String].self, forKey: .metadata)
             switch self.type {
-            case .getEvaluationLatency:
-                let data = try container.decode(MetricsEventData.GetEvaluationLatency.self, forKey: .event)
-                self.event = .getEvaluationLatency(data)
+            case .responseLatency:
+                let data = try container.decode(MetricsEventData.ResponseLatency.self, forKey: .event)
+                self.event = .responseLatency(data)
             case .getEvaluationSize:
                 let data = try container.decode(MetricsEventData.GetEvaluationSize.self, forKey: .event)
                 self.event = .getEvaluationSize(data)
@@ -116,7 +116,7 @@ enum EventData: Hashable {
             }
             try container.encode(metadata, forKey: .metadata)
             switch self.event {
-            case .getEvaluationLatency(let eventData):
+            case .responseLatency(let eventData):
                 try container.encode(eventData, forKey: .event)
             case .getEvaluationSize(let eventData):
                 try container.encode(eventData, forKey: .event)

--- a/Bucketeer/Sources/Internal/Model/EventData.swift
+++ b/Bucketeer/Sources/Internal/Model/EventData.swift
@@ -68,9 +68,9 @@ enum EventData: Hashable {
             case .responseLatency:
                 let data = try container.decode(MetricsEventData.ResponseLatency.self, forKey: .event)
                 self.event = .responseLatency(data)
-            case .getEvaluationSize:
-                let data = try container.decode(MetricsEventData.GetEvaluationSize.self, forKey: .event)
-                self.event = .getEvaluationSize(data)
+            case .responseSize:
+                let data = try container.decode(MetricsEventData.ResponseSize.self, forKey: .event)
+                self.event = .responseSize(data)
             case .timeoutError:
                 let data = try container.decode(MetricsEventData.TimeoutError.self, forKey: .event)
                 self.event = .timeoutError(data)
@@ -118,7 +118,7 @@ enum EventData: Hashable {
             switch self.event {
             case .responseLatency(let eventData):
                 try container.encode(eventData, forKey: .event)
-            case .getEvaluationSize(let eventData):
+            case .responseSize(let eventData):
                 try container.encode(eventData, forKey: .event)
             case .timeoutError(let eventData):
                 try container.encode(eventData, forKey: .event)

--- a/Bucketeer/Sources/Internal/Model/EventData.swift
+++ b/Bucketeer/Sources/Internal/Model/EventData.swift
@@ -132,5 +132,10 @@ enum EventData: Hashable {
                 try container.encode(protobufType, forKey: .protobufType)
             }
         }
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(event)
+            hasher.combine(type)
+        }
     }
 }

--- a/Bucketeer/Sources/Internal/Model/EventData.swift
+++ b/Bucketeer/Sources/Internal/Model/EventData.swift
@@ -86,6 +86,15 @@ enum EventData: Hashable {
             case .forbiddenError:
                 let data = try container.decode(MetricsEventData.ForbiddenError.self, forKey: .event)
                 self.event = .forbiddenError(data)
+            case .notFoundError:
+                let data = try container.decode(MetricsEventData.NotFoundError.self, forKey: .event)
+                self.event = .notFoundError(data)
+            case .clientClosedError:
+                let data = try container.decode(MetricsEventData.ClientClosedError.self, forKey: .event)
+                self.event = .clientClosedError(data)
+            case .unavailableError:
+                let data = try container.decode(MetricsEventData.UnavailableError.self, forKey: .event)
+                self.event = .unavailableError(data)
             case .internalError:
                 let data = try container.decode(MetricsEventData.InternalSdkError.self, forKey: .event)
                 self.event = .internalSdkError(data)
@@ -120,6 +129,12 @@ enum EventData: Hashable {
             case .unauthorizedError(let eventData):
                 try container.encode(eventData, forKey: .event)
             case .forbiddenError(let eventData):
+                try container.encode(eventData, forKey: .event)
+            case .notFoundError(let eventData):
+                try container.encode(eventData, forKey: .event)
+            case .clientClosedError(let eventData):
+                try container.encode(eventData, forKey: .event)
+            case .unavailableError(let eventData):
                 try container.encode(eventData, forKey: .event)
             case .internalSdkError(let eventData):
                 try container.encode(eventData, forKey: .event)

--- a/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum MetricsEventData: Hashable {
-    case getEvaluationLatency(GetEvaluationLatency)
+    case responseLatency(ResponseLatency)
     case getEvaluationSize(GetEvaluationSize)
     case timeoutError(TimeoutError)
     case networkError(NetworkError)
@@ -15,7 +15,7 @@ enum MetricsEventData: Hashable {
     case internalServerError(InternalServerError)
     case unknownError(UnknownError)
 
-    struct GetEvaluationLatency: Codable, Hashable {
+    struct ResponseLatency: Codable, Hashable {
         let apiId: ApiId
         let labels: [String: String]
         let latencySecond: Float64

--- a/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
@@ -5,7 +5,12 @@ enum MetricsEventData: Hashable {
     case getEvaluationSize(GetEvaluationSize)
     case timeoutError(TimeoutError)
     case networkError(NetworkError)
+    case badRequestError(BadRequestError)
+    case unauthorizedError(UnauthorizedError)
+    case forbiddenError(ForbiddenError)
     case internalSdkError(InternalSdkError)
+    case internalServerError(InternalServerError)
+    case unknownError(UnknownError)
 
     struct GetEvaluationLatency: Codable, Hashable {
         let apiId: ApiId
@@ -33,9 +38,39 @@ enum MetricsEventData: Hashable {
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.NetworkErrorMetricsEvent"
     }
 
+    struct BadRequestError: Codable, Hashable {
+        let apiId: ApiId
+        let labels: [String: String]
+        var protobufType: String? = "type.googleapis.com/bucketeer.event.client.BadRequestErrorMetricsEvent"
+    }
+
+    struct UnauthorizedError: Codable, Hashable {
+        let apiId: ApiId
+        let labels: [String: String]
+        var protobufType: String? = "type.googleapis.com/bucketeer.event.client.UnauthorizedErrorMetricsEvent"
+    }
+
+    struct ForbiddenError: Codable, Hashable {
+        let apiId: ApiId
+        let labels: [String: String]
+        var protobufType: String? = "type.googleapis.com/bucketeer.event.client.ForbiddenErrorMetricsEvent"
+    }
+
     struct InternalSdkError: Codable, Hashable {
         let apiId: ApiId
         let labels: [String: String]
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.InternalSdkErrorMetricsEvent"
+    }
+
+    struct InternalServerError: Codable, Hashable {
+        let apiId: ApiId
+        let labels: [String: String]
+        var protobufType: String? = "type.googleapis.com/bucketeer.event.client.InternalServerErrorMetricsEvent"
+    }
+
+    struct UnknownError: Codable, Hashable {
+        let apiId: ApiId
+        let labels: [String: String]
+        var protobufType: String? = "type.googleapis.com/bucketeer.event.client.UnknownErrorMetricsEvent"
     }
 }

--- a/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
@@ -18,12 +18,12 @@ enum MetricsEventData: Hashable {
     struct GetEvaluationLatency: Codable, Hashable {
         let apiId: ApiId
         let labels: [String: String]
-        let duration: Float64
+        let latencySecond: Float64
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.LatencyMetricsEvent"
 
         func hash(into hasher: inout Hasher) {
             hasher.combine(apiId)
-            hasher.combine(duration)
+            hasher.combine(latencySecond)
         }
     }
 

--- a/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum MetricsEventData: Hashable {
     case responseLatency(ResponseLatency)
-    case getEvaluationSize(GetEvaluationSize)
+    case responseSize(ResponseSize)
     case timeoutError(TimeoutError)
     case networkError(NetworkError)
     case badRequestError(BadRequestError)
@@ -27,7 +27,7 @@ enum MetricsEventData: Hashable {
         }
     }
 
-    struct GetEvaluationSize: Codable, Hashable {
+    struct ResponseSize: Codable, Hashable {
         let apiId: ApiId
         let labels: [String: String]
         let size_byte: Int64

--- a/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
@@ -8,6 +8,9 @@ enum MetricsEventData: Hashable {
     case badRequestError(BadRequestError)
     case unauthorizedError(UnauthorizedError)
     case forbiddenError(ForbiddenError)
+    case notFoundError(NotFoundError)
+    case clientClosedError(ClientClosedError)
+    case unavailableError(UnavailableError)
     case internalSdkError(InternalSdkError)
     case internalServerError(InternalServerError)
     case unknownError(UnknownError)
@@ -16,7 +19,7 @@ enum MetricsEventData: Hashable {
         let apiId: ApiId
         let labels: [String: String]
         let duration: Float64
-        var protobufType: String? = "type.googleapis.com/bucketeer.event.client.GetEvaluationLatencyMetricsEvent"
+        var protobufType: String? = "type.googleapis.com/bucketeer.event.client.LatencyMetricsEvent"
 
         func hash(into hasher: inout Hasher) {
             hasher.combine(apiId)
@@ -28,7 +31,7 @@ enum MetricsEventData: Hashable {
         let apiId: ApiId
         let labels: [String: String]
         let size_byte: Int64
-        var protobufType: String? = "type.googleapis.com/bucketeer.event.client.GetEvaluationSizeMetricsEvent"
+        var protobufType: String? = "type.googleapis.com/bucketeer.event.client.SizeMetricsEvent"
 
         func hash(into hasher: inout Hasher) {
             hasher.combine(apiId)
@@ -80,6 +83,36 @@ enum MetricsEventData: Hashable {
         let apiId: ApiId
         let labels: [String: String]
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.ForbiddenErrorMetricsEvent"
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(apiId)
+        }
+    }
+
+    struct NotFoundError: Codable, Hashable {
+        let apiId: ApiId
+        let labels: [String: String]
+        var protobufType: String? = "type.googleapis.com/bucketeer.event.client.NotFoundErrorMetricsEvent"
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(apiId)
+        }
+    }
+
+    struct ClientClosedError: Codable, Hashable {
+        let apiId: ApiId
+        let labels: [String: String]
+        var protobufType: String? = "type.googleapis.com/bucketeer.event.client.ClientClosedRequestErrorMetricsEvent"
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(apiId)
+        }
+    }
+
+    struct UnavailableError: Codable, Hashable {
+        let apiId: ApiId
+        let labels: [String: String]
+        var protobufType: String? = "type.googleapis.com/bucketeer.event.client.ServiceUnavailableErrorMetricsEvent"
 
         func hash(into hasher: inout Hasher) {
             hasher.combine(apiId)

--- a/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
@@ -17,6 +17,11 @@ enum MetricsEventData: Hashable {
         let labels: [String: String]
         let duration: Duration
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.GetEvaluationLatencyMetricsEvent"
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(apiId)
+            hasher.combine(duration)
+        }
     }
 
     struct GetEvaluationSize: Codable, Hashable {
@@ -24,53 +29,90 @@ enum MetricsEventData: Hashable {
         let labels: [String: String]
         let size_byte: Int64
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.GetEvaluationSizeMetricsEvent"
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(apiId)
+            hasher.combine(size_byte)
+        }
     }
 
     struct TimeoutError: Codable, Hashable {
         let apiId: ApiId
         let labels: [String: String]
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.TimeoutErrorMetricsEvent"
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(apiId)
+        }
     }
 
     struct NetworkError: Codable, Hashable {
         let apiId: ApiId
         let labels: [String: String]
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.NetworkErrorMetricsEvent"
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(apiId)
+        }
     }
 
     struct BadRequestError: Codable, Hashable {
         let apiId: ApiId
         let labels: [String: String]
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.BadRequestErrorMetricsEvent"
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(apiId)
+        }
     }
 
     struct UnauthorizedError: Codable, Hashable {
         let apiId: ApiId
         let labels: [String: String]
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.UnauthorizedErrorMetricsEvent"
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(apiId)
+        }
     }
 
     struct ForbiddenError: Codable, Hashable {
         let apiId: ApiId
         let labels: [String: String]
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.ForbiddenErrorMetricsEvent"
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(apiId)
+        }
     }
 
     struct InternalSdkError: Codable, Hashable {
         let apiId: ApiId
         let labels: [String: String]
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.InternalSdkErrorMetricsEvent"
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(apiId)
+        }
     }
 
     struct InternalServerError: Codable, Hashable {
         let apiId: ApiId
         let labels: [String: String]
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.InternalServerErrorMetricsEvent"
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(apiId)
+        }
     }
 
     struct UnknownError: Codable, Hashable {
         let apiId: ApiId
         let labels: [String: String]
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.UnknownErrorMetricsEvent"
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(apiId)
+        }
     }
 }

--- a/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
@@ -18,7 +18,7 @@ enum MetricsEventData: Hashable {
     struct ResponseLatency: Codable, Hashable {
         let apiId: ApiId
         let labels: [String: String]
-        let latencySecond: Float64
+        let latencySecond: Double
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.LatencyMetricsEvent"
 
         func hash(into hasher: inout Hasher) {

--- a/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
@@ -15,7 +15,7 @@ enum MetricsEventData: Hashable {
     struct GetEvaluationLatency: Codable, Hashable {
         let apiId: ApiId
         let labels: [String: String]
-        let duration: Duration
+        let duration: Float64
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.GetEvaluationLatencyMetricsEvent"
 
         func hash(into hasher: inout Hasher) {

--- a/Bucketeer/Sources/Internal/Model/MetricsEventType.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventType.swift
@@ -1,10 +1,9 @@
 import Foundation
 
 enum MetricsEventType: Int, Codable, Hashable {
+    case unknownError = 0
     case responseLatency = 1
     case responseSize = 2
-//    case timeoutErrorCount = 3 // deprecated
-//    case internalErrorCount = 4 // deprecated
     case timeoutError = 5
     case networkError = 6
     case internalError = 7
@@ -15,5 +14,4 @@ enum MetricsEventType: Int, Codable, Hashable {
     case clientClosedError = 12
     case unavailableError = 13
     case internalServerError = 14
-    case unknownError = 15
 }

--- a/Bucketeer/Sources/Internal/Model/MetricsEventType.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventType.swift
@@ -2,16 +2,16 @@ import Foundation
 
 enum MetricsEventType: Int, Codable, Hashable {
     case unknownError = 0
-    case responseLatency = 1
-    case responseSize = 2
-    case timeoutError = 5
-    case networkError = 6
-    case internalError = 7
-    case badRequestError = 8
-    case unauthorizedError = 9
-    case forbiddenError = 10
-    case notFoundError = 11
-    case clientClosedError = 12
-    case unavailableError = 13
-    case internalServerError = 14
+    case responseLatency
+    case responseSize
+    case timeoutError
+    case networkError
+    case internalError
+    case badRequestError
+    case unauthorizedError
+    case forbiddenError
+    case notFoundError
+    case clientClosedError
+    case unavailableError
+    case internalServerError
 }

--- a/Bucketeer/Sources/Internal/Model/MetricsEventType.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventType.swift
@@ -8,4 +8,9 @@ enum MetricsEventType: Int, Codable, Hashable {
     case timeoutError = 5
     case networkError = 6
     case internalError = 7
+    case badRequestError = 8
+    case unauthorizedError = 9
+    case forbiddenError = 10
+    case internalServerError = 11
+    case unknownError = 12
 }

--- a/Bucketeer/Sources/Internal/Model/MetricsEventType.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventType.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum MetricsEventType: Int, Codable, Hashable {
     case responseLatency = 1
-    case getEvaluationSize = 2
+    case responseSize = 2
 //    case timeoutErrorCount = 3 // deprecated
 //    case internalErrorCount = 4 // deprecated
     case timeoutError = 5

--- a/Bucketeer/Sources/Internal/Model/MetricsEventType.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventType.swift
@@ -11,6 +11,9 @@ enum MetricsEventType: Int, Codable, Hashable {
     case badRequestError = 8
     case unauthorizedError = 9
     case forbiddenError = 10
-    case internalServerError = 11
-    case unknownError = 12
+    case notFoundError = 11
+    case clientClosedError = 12
+    case unavailableError = 13
+    case internalServerError = 14
+    case unknownError = 15
 }

--- a/Bucketeer/Sources/Internal/Model/MetricsEventType.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventType.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum MetricsEventType: Int, Codable, Hashable {
-    case getEvaluationLatency = 1
+    case responseLatency = 1
     case getEvaluationSize = 2
 //    case timeoutErrorCount = 3 // deprecated
 //    case internalErrorCount = 4 // deprecated

--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -45,8 +45,8 @@ final class ApiClientImpl: ApiClient {
                 switch result {
                 case .success((var response, let urlResponse)):
                     let endAt = Date()
-                    let duration = endAt.timeIntervalSince(startAt)
-                    response.seconds = duration
+                    let latencySecond = endAt.timeIntervalSince(startAt)
+                    response.seconds = latencySecond
                     let contentLength = urlResponse.expectedContentLength
                     response.sizeByte = contentLength
                     response.featureTag = featureTag

--- a/Bucketeer/Sources/Internal/Scheduler/EvaluationForegroundTask.swift
+++ b/Bucketeer/Sources/Internal/Scheduler/EvaluationForegroundTask.swift
@@ -56,7 +56,7 @@ final class EvaluationForegroundTask: ScheduledTask {
                 case .success(let response):
                     try eventInteractor.trackFetchEvaluationsSuccess(
                         featureTag: response.featureTag,
-                        seconds: Int64(response.seconds),
+                        seconds: response.seconds,
                         sizeByte: response.sizeByte
                     )
                     // reset retry count

--- a/Bucketeer/Sources/Public/BKTClient.swift
+++ b/Bucketeer/Sources/Public/BKTClient.swift
@@ -147,7 +147,7 @@ extension BKTClient {
         component.userHolder.updateAttributes { _ in
             attributes
         }
-        component.evaluationInteractor.resetCurrentEvaluationsId()
+        component.evaluationInteractor.clearCurrentEvaluationsId()
     }
 
     public func fetchEvaluations(timeoutMillis: Int64?, completion: ((BKTError?) -> Void)?) {

--- a/Bucketeer/Sources/Public/BKTClient.swift
+++ b/Bucketeer/Sources/Public/BKTClient.swift
@@ -222,7 +222,7 @@ extension BKTClient {
                       case .success(let response):
                           try interactor.trackFetchEvaluationsSuccess(
                             featureTag: response.featureTag,
-                            seconds: Int64(response.seconds),
+                            seconds: response.seconds,
                             sizeByte: response.sizeByte
                           )
                           completion?(nil)

--- a/Bucketeer/Sources/Public/BKTClient.swift
+++ b/Bucketeer/Sources/Public/BKTClient.swift
@@ -77,6 +77,7 @@ extension BKTClient {
         precondition(Thread.isMainThread, "the initialize method must be called on main thread")
         guard BKTClient.default == nil else {
             config.logger?.warn(message: "BKTClient is already initialized. Not sure if the initial fetch has finished")
+            completion?(nil)
             return
         }
         do {
@@ -91,6 +92,7 @@ extension BKTClient {
             }
         } catch let error {
             config.logger?.error(error)
+            completion?(error as? BKTError)
         }
     }
 

--- a/Bucketeer/Sources/Public/BKTClient.swift
+++ b/Bucketeer/Sources/Public/BKTClient.swift
@@ -147,6 +147,7 @@ extension BKTClient {
         component.userHolder.updateAttributes { _ in
             attributes
         }
+        component.evaluationInteractor.resetCurrentEvaluationsId()
     }
 
     public func fetchEvaluations(timeoutMillis: Int64?, completion: ((BKTError?) -> Void)?) {

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -5,7 +5,6 @@ public enum BKTError: Error, Equatable {
     case unauthorized(message: String)
     case forbidden(message: String)
     case notFound(message: String)
-    case invalidHttpMethod(message: String)
     case clientClosed(message: String)
     case unavailable(message: String)
     case apiServer(message: String)
@@ -27,7 +26,6 @@ public enum BKTError: Error, Equatable {
             (.unauthorized(let m1), .unauthorized(let m2)),
             (.forbidden(let m1), .forbidden(let m2)),
             (.notFound(let m1), .notFound(let m2)),
-            (.invalidHttpMethod(let m1), .invalidHttpMethod(let m2)),
             (.clientClosed(let m1), .clientClosed(let m2)),
             (.unavailable(let m1), .unavailable(let m2)),
             (.apiServer(let m1), .apiServer(let m2)),
@@ -63,8 +61,6 @@ extension BKTError {
                     self = .forbidden(message: errorResponse?.error.message ?? "Forbidden error")
                 case 404:
                     self = .notFound(message: errorResponse?.error.message ?? "NotFound error")
-                case 405:
-                    self = .invalidHttpMethod(message: errorResponse?.error.message ?? "MethodNotAllowed error")
                 case 499:
                     self = .clientClosed(message: errorResponse?.error.message ?? "Client Closed Request error")
                 case 500:

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -6,6 +6,8 @@ public enum BKTError: Error, Equatable {
     case forbidden(message: String)
     case featureNotFound(message: String)
     case invalidHttpMethod(message: String)
+    case clientClosed(message: String)
+    case unavailable(message: String)
     case apiServer(message: String)
 
     // network errors
@@ -26,6 +28,8 @@ public enum BKTError: Error, Equatable {
             (.forbidden(let m1), .forbidden(let m2)),
             (.featureNotFound(let m1), .featureNotFound(let m2)),
             (.invalidHttpMethod(let m1), .invalidHttpMethod(let m2)),
+            (.clientClosed(let m1), .clientClosed(let m2)),
+            (.unavailable(let m1), .unavailable(let m2)),
             (.apiServer(let m1), .apiServer(let m2)),
             (.illegalArgument(let m1), .illegalArgument(let m2)),
             (.illegalState(let m1), .illegalState(let m2)):
@@ -61,6 +65,10 @@ extension BKTError {
                     self = .featureNotFound(message: errorResponse?.error.message ?? "NotFound error")
                 case 405:
                     self = .invalidHttpMethod(message: errorResponse?.error.message ?? "MethodNotAllowed error")
+                case 409:
+                    self = .clientClosed(message: errorResponse?.error.message ?? "Client Closed Request error")
+                case 503:
+                    self = .unavailable(message: errorResponse?.error.message ?? "Unavailable error")
                 case 500..<600:
                     self = .apiServer(message: errorResponse?.error.message ?? "InternalServer error")
                 default:

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum BKTError: Error, Equatable {
     case badRequest(message: String)
     case unauthorized(message: String)
+    case forbidden(message: String)
     case invalidHttpMethod(message: String)
     case apiServer(message: String)
 
@@ -21,6 +22,7 @@ public enum BKTError: Error, Equatable {
         switch (lhs, rhs) {
         case (.badRequest(let m1), .badRequest(let m2)),
             (.unauthorized(let m1), .unauthorized(let m2)),
+            (.forbidden(let m1), .forbidden(let m2)),
             (.invalidHttpMethod(let m1), .invalidHttpMethod(let m2)),
             (.apiServer(let m1), .apiServer(let m2)),
             (.illegalArgument(let m1), .illegalArgument(let m2)),
@@ -51,6 +53,8 @@ extension BKTError {
                     self = .badRequest(message: errorResponse?.error.message ?? "BadRequest error")
                 case 401:
                     self = .unauthorized(message: errorResponse?.error.message ?? "Unauthorized error")
+                case 403:
+                    self = .forbidden(message: errorResponse?.error.message ?? "Forbidden error")
                 case 405:
                     self = .invalidHttpMethod(message: errorResponse?.error.message ?? "MethodNotAllowed error")
                 case 500..<600:

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -65,7 +65,7 @@ extension BKTError {
                     self = .notFound(message: errorResponse?.error.message ?? "NotFound error")
                 case 405:
                     self = .invalidHttpMethod(message: errorResponse?.error.message ?? "MethodNotAllowed error")
-                case 409:
+                case 499:
                     self = .clientClosed(message: errorResponse?.error.message ?? "Client Closed Request error")
                 case 500:
                     self = .apiServer(message: errorResponse?.error.message ?? "InternalServer error")

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -3,7 +3,6 @@ import Foundation
 public enum BKTError: Error, Equatable {
     case badRequest(message: String)
     case unauthorized(message: String)
-    case featureNotFound(message: String)
     case invalidHttpMethod(message: String)
     case apiServer(message: String)
 
@@ -22,7 +21,6 @@ public enum BKTError: Error, Equatable {
         switch (lhs, rhs) {
         case (.badRequest(let m1), .badRequest(let m2)),
             (.unauthorized(let m1), .unauthorized(let m2)),
-            (.featureNotFound(let m1), .featureNotFound(let m2)),
             (.invalidHttpMethod(let m1), .invalidHttpMethod(let m2)),
             (.apiServer(let m1), .apiServer(let m2)),
             (.illegalArgument(let m1), .illegalArgument(let m2)),
@@ -53,8 +51,6 @@ extension BKTError {
                     self = .badRequest(message: errorResponse?.error.message ?? "BadRequest error")
                 case 401:
                     self = .unauthorized(message: errorResponse?.error.message ?? "Unauthorized error")
-                case 404:
-                    self = .featureNotFound(message: errorResponse?.error.message ?? "NotFound error")
                 case 405:
                     self = .invalidHttpMethod(message: errorResponse?.error.message ?? "MethodNotAllowed error")
                 case 500:

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -67,10 +67,10 @@ extension BKTError {
                     self = .invalidHttpMethod(message: errorResponse?.error.message ?? "MethodNotAllowed error")
                 case 409:
                     self = .clientClosed(message: errorResponse?.error.message ?? "Client Closed Request error")
+                case 500:
+                    self = .apiServer(message: errorResponse?.error.message ?? "InternalServer error")
                 case 503:
                     self = .unavailable(message: errorResponse?.error.message ?? "Unavailable error")
-                case 500..<600:
-                    self = .apiServer(message: errorResponse?.error.message ?? "InternalServer error")
                 default:
                     var message: String = "no error body"
                     if let errorResponse = errorResponse {

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -18,6 +18,7 @@ public enum BKTError: Error, Equatable {
     case illegalState(message: String)
 
     // unknown errors
+    case unknownServer(message: String, error: Error)
     case unknown(message: String, error: Error)
 
     public static func == (lhs: BKTError, rhs: BKTError) -> Bool {
@@ -34,6 +35,7 @@ public enum BKTError: Error, Equatable {
             return m1 == m2
         case (.timeout(let m1, _), .timeout(let m2, _)),
             (.network(let m1, _), .network(let m2, _)),
+            (.unknownServer(let m1, _), .unknownServer(let m2, _)),
             (.unknown(let m1, _), .unknown(let m2, _)):
             return m1 == m2
         default:
@@ -72,7 +74,7 @@ extension BKTError {
                     if let errorResponse = errorResponse {
                         message = "[\(errorResponse.error.code)] \(errorResponse.error.message)"
                     }
-                    self = .unknown(message: "Unknown error: \(message)", error: error)
+                    self = .unknownServer(message: "Unknown server error: \(message)", error: error)
                 }
             case .unknown(let urlResponse):
                 var message: String = "no response"

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -4,6 +4,7 @@ public enum BKTError: Error, Equatable {
     case badRequest(message: String)
     case unauthorized(message: String)
     case forbidden(message: String)
+    case featureNotFound(message: String)
     case invalidHttpMethod(message: String)
     case apiServer(message: String)
 
@@ -23,6 +24,7 @@ public enum BKTError: Error, Equatable {
         case (.badRequest(let m1), .badRequest(let m2)),
             (.unauthorized(let m1), .unauthorized(let m2)),
             (.forbidden(let m1), .forbidden(let m2)),
+            (.featureNotFound(let m1), .featureNotFound(let m2)),
             (.invalidHttpMethod(let m1), .invalidHttpMethod(let m2)),
             (.apiServer(let m1), .apiServer(let m2)),
             (.illegalArgument(let m1), .illegalArgument(let m2)),
@@ -55,6 +57,8 @@ extension BKTError {
                     self = .unauthorized(message: errorResponse?.error.message ?? "Unauthorized error")
                 case 403:
                     self = .forbidden(message: errorResponse?.error.message ?? "Forbidden error")
+                case 404:
+                    self = .featureNotFound(message: errorResponse?.error.message ?? "NotFound error")
                 case 405:
                     self = .invalidHttpMethod(message: errorResponse?.error.message ?? "MethodNotAllowed error")
                 case 500..<600:

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -53,7 +53,7 @@ extension BKTError {
                     self = .unauthorized(message: errorResponse?.error.message ?? "Unauthorized error")
                 case 405:
                     self = .invalidHttpMethod(message: errorResponse?.error.message ?? "MethodNotAllowed error")
-                case 500:
+                case 500..<600:
                     self = .apiServer(message: errorResponse?.error.message ?? "InternalServer error")
                 default:
                     var message: String = "no error body"

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -4,7 +4,7 @@ public enum BKTError: Error, Equatable {
     case badRequest(message: String)
     case unauthorized(message: String)
     case forbidden(message: String)
-    case featureNotFound(message: String)
+    case notFound(message: String)
     case invalidHttpMethod(message: String)
     case clientClosed(message: String)
     case unavailable(message: String)
@@ -26,7 +26,7 @@ public enum BKTError: Error, Equatable {
         case (.badRequest(let m1), .badRequest(let m2)),
             (.unauthorized(let m1), .unauthorized(let m2)),
             (.forbidden(let m1), .forbidden(let m2)),
-            (.featureNotFound(let m1), .featureNotFound(let m2)),
+            (.notFound(let m1), .notFound(let m2)),
             (.invalidHttpMethod(let m1), .invalidHttpMethod(let m2)),
             (.clientClosed(let m1), .clientClosed(let m2)),
             (.unavailable(let m1), .unavailable(let m2)),
@@ -62,7 +62,7 @@ extension BKTError {
                 case 403:
                     self = .forbidden(message: errorResponse?.error.message ?? "Forbidden error")
                 case 404:
-                    self = .featureNotFound(message: errorResponse?.error.message ?? "NotFound error")
+                    self = .notFound(message: errorResponse?.error.message ?? "NotFound error")
                 case 405:
                     self = .invalidHttpMethod(message: errorResponse?.error.message ?? "MethodNotAllowed error")
                 case 409:

--- a/BucketeerTests/BKTClientTests.swift
+++ b/BucketeerTests/BKTClientTests.swift
@@ -78,6 +78,7 @@ final class BKTClientTests: XCTestCase {
                                 latencySecond: .init(2)
                             )),
                             type: .responseLatency,
+                            sourceId: .ios,
                             sdk_version: "0.0.2",
                             metadata: [
                                 "app_version": "1.2.3",
@@ -98,6 +99,7 @@ final class BKTClientTests: XCTestCase {
                                 size_byte: 3
                             )),
                             type: .responseSize,
+                            sourceId: .ios,
                             sdk_version: "0.0.2",
                             metadata: [
                                 "app_version": "1.2.3",
@@ -145,6 +147,7 @@ final class BKTClientTests: XCTestCase {
                         timestamp: 1,
                         event: .timeoutError(.init(apiId: .getEvaluations, labels: ["tag": "feature"])),
                         type: .timeoutError,
+                        sourceId: .ios,
                         sdk_version: "0.0.2",
                         metadata: [
                             "app_version": "1.2.3",

--- a/BucketeerTests/BKTClientTests.swift
+++ b/BucketeerTests/BKTClientTests.swift
@@ -75,7 +75,7 @@ final class BKTClientTests: XCTestCase {
                             event: .getEvaluationLatency(.init(
                                 apiId: .getEvaluations,
                                 labels: ["tag": "feature"],
-                                duration: .init(2)
+                                latencySecond: .init(2)
                             )),
                             type: .getEvaluationLatency,
                             sdk_version: "0.0.2",

--- a/BucketeerTests/BKTClientTests.swift
+++ b/BucketeerTests/BKTClientTests.swift
@@ -92,12 +92,12 @@ final class BKTClientTests: XCTestCase {
                         id: "mock2",
                         event: .metrics(.init(
                             timestamp: 1,
-                            event: .getEvaluationSize(.init(
+                            event: .responseSize(.init(
                                 apiId: .getEvaluations,
                                 labels: ["tag": "feature"],
                                 size_byte: 3
                             )),
-                            type: .getEvaluationSize,
+                            type: .responseSize,
                             sdk_version: "0.0.2",
                             metadata: [
                                 "app_version": "1.2.3",

--- a/BucketeerTests/BKTClientTests.swift
+++ b/BucketeerTests/BKTClientTests.swift
@@ -75,7 +75,7 @@ final class BKTClientTests: XCTestCase {
                             event: .getEvaluationLatency(.init(
                                 apiId: .getEvaluations,
                                 labels: ["tag": "feature"],
-                                duration: .init(seconds: 2)
+                                duration: .init(2)
                             )),
                             type: .getEvaluationLatency,
                             sdk_version: "0.0.2",

--- a/BucketeerTests/BKTClientTests.swift
+++ b/BucketeerTests/BKTClientTests.swift
@@ -72,12 +72,12 @@ final class BKTClientTests: XCTestCase {
                         id: "mock1",
                         event: .metrics(.init(
                             timestamp: 1,
-                            event: .getEvaluationLatency(.init(
+                            event: .responseLatency(.init(
                                 apiId: .getEvaluations,
                                 labels: ["tag": "feature"],
                                 latencySecond: .init(2)
                             )),
-                            type: .getEvaluationLatency,
+                            type: .responseLatency,
                             sdk_version: "0.0.2",
                             metadata: [
                                 "app_version": "1.2.3",

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -20,7 +20,6 @@ class BKTErrorTests: XCTestCase {
         assertEqual(.unauthorized(message: "1"), .unauthorized(message: "1"))
         assertEqual(.forbidden(message: "1"), .forbidden(message: "1"))
         assertEqual(.notFound(message: "1"), .notFound(message: "1"))
-        assertEqual(.invalidHttpMethod(message: "1"), .invalidHttpMethod(message: "1"))
         assertEqual(.clientClosed(message: "1"), .clientClosed(message: "1"))
         assertEqual(.unavailable(message: "1"), .unavailable(message: "1"))
         assertEqual(.apiServer(message: "1"), .apiServer(message: "1"))
@@ -58,7 +57,6 @@ class BKTErrorTests: XCTestCase {
         assertNotEqual(.unauthorized(message: "1"), .unauthorized(message: "2"))
         assertNotEqual(.forbidden(message: "1"), .forbidden(message: "2"))
         assertNotEqual(.notFound(message: "1"), .notFound(message: "2"))
-        assertNotEqual(.invalidHttpMethod(message: "1"), .invalidHttpMethod(message: "2"))
         assertNotEqual(.clientClosed(message: "1"), .clientClosed(message: "2"))
         assertNotEqual(.unavailable(message: "1"), .unavailable(message: "2"))
         assertNotEqual(.apiServer(message: "1"), .apiServer(message: "2"))
@@ -99,10 +97,6 @@ class BKTErrorTests: XCTestCase {
         assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 404, response: nil)),
             .notFound(message: "NotFound error")
-        )
-        assertEqual(
-            .init(error: ResponseError.unacceptableCode(code: 405, response: nil)),
-            .invalidHttpMethod(message: "MethodNotAllowed error")
         )
         assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 499, response: nil)),

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -110,17 +110,13 @@ class BKTErrorTests: XCTestCase {
             .init(error: ResponseError.unacceptableCode(code: 503, response: nil)),
             .unavailable(message: "Unavailable error")
         )
+        let errorResponse = ErrorResponse(error: .init(code: 450, message: "some error"))
         assertEqual(
-            .init(error: ResponseError.unacceptableCode(code: 599, response: nil)),
-            .apiServer(message: "InternalServer error")
-        )
-        let errorResponse = ErrorResponse(error: .init(code: 499, message: "some error"))
-        assertEqual(
-            .init(error: ResponseError.unacceptableCode(code: 499, response: errorResponse)),
-            .unknown(message: "Unknown error: [499] some error", error: SomeError.a)
+            .init(error: ResponseError.unacceptableCode(code: 450, response: errorResponse)),
+            .unknown(message: "Unknown error: [450] some error", error: SomeError.a)
         )
         assertEqual(
-            .init(error: ResponseError.unacceptableCode(code: 499, response: nil)),
+            .init(error: ResponseError.unacceptableCode(code: 450, response: nil)),
             .unknown(message: "Unknown error: no error body", error: SomeError.a)
         )
 

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -18,7 +18,6 @@ class BKTErrorTests: XCTestCase {
         // equal
         assertEqual(.badRequest(message: "1"), .badRequest(message: "1"))
         assertEqual(.unauthorized(message: "1"), .unauthorized(message: "1"))
-        assertEqual(.featureNotFound(message: "1"), .featureNotFound(message: "1"))
         assertEqual(.invalidHttpMethod(message: "1"), .invalidHttpMethod(message: "1"))
         assertEqual(.apiServer(message: "1"), .apiServer(message: "1"))
         assertEqual(
@@ -53,7 +52,6 @@ class BKTErrorTests: XCTestCase {
         // not equal
         assertNotEqual(.badRequest(message: "1"), .badRequest(message: "2"))
         assertNotEqual(.unauthorized(message: "1"), .unauthorized(message: "2"))
-        assertNotEqual(.featureNotFound(message: "1"), .featureNotFound(message: "2"))
         assertNotEqual(.invalidHttpMethod(message: "1"), .invalidHttpMethod(message: "2"))
         assertNotEqual(.apiServer(message: "1"), .apiServer(message: "2"))
         assertNotEqual(
@@ -89,10 +87,6 @@ class BKTErrorTests: XCTestCase {
         assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 401, response: nil)),
             .unauthorized(message: "Unauthorized error")
-        )
-        assertEqual(
-            .init(error: ResponseError.unacceptableCode(code: 404, response: nil)),
-            .featureNotFound(message: "NotFound error")
         )
         assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 405, response: nil)),

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -19,6 +19,7 @@ class BKTErrorTests: XCTestCase {
         assertEqual(.badRequest(message: "1"), .badRequest(message: "1"))
         assertEqual(.unauthorized(message: "1"), .unauthorized(message: "1"))
         assertEqual(.forbidden(message: "1"), .forbidden(message: "1"))
+        assertEqual(.featureNotFound(message: "1"), .featureNotFound(message: "1"))
         assertEqual(.invalidHttpMethod(message: "1"), .invalidHttpMethod(message: "1"))
         assertEqual(.apiServer(message: "1"), .apiServer(message: "1"))
         assertEqual(
@@ -54,6 +55,7 @@ class BKTErrorTests: XCTestCase {
         assertNotEqual(.badRequest(message: "1"), .badRequest(message: "2"))
         assertNotEqual(.unauthorized(message: "1"), .unauthorized(message: "2"))
         assertNotEqual(.forbidden(message: "1"), .forbidden(message: "2"))
+        assertNotEqual(.featureNotFound(message: "1"), .featureNotFound(message: "2"))
         assertNotEqual(.invalidHttpMethod(message: "1"), .invalidHttpMethod(message: "2"))
         assertNotEqual(.apiServer(message: "1"), .apiServer(message: "2"))
         assertNotEqual(
@@ -89,6 +91,10 @@ class BKTErrorTests: XCTestCase {
         assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 403, response: nil)),
             .forbidden(message: "Forbidden error")
+        )
+        assertEqual(
+            .init(error: ResponseError.unacceptableCode(code: 404, response: nil)),
+            .featureNotFound(message: "NotFound error")
         )
         assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 405, response: nil)),

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -105,7 +105,7 @@ class BKTErrorTests: XCTestCase {
             .invalidHttpMethod(message: "MethodNotAllowed error")
         )
         assertEqual(
-            .init(error: ResponseError.unacceptableCode(code: 409, response: nil)),
+            .init(error: ResponseError.unacceptableCode(code: 499, response: nil)),
             .clientClosed(message: "Client Closed Request error")
         )
         assertEqual(

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -19,7 +19,7 @@ class BKTErrorTests: XCTestCase {
         assertEqual(.badRequest(message: "1"), .badRequest(message: "1"))
         assertEqual(.unauthorized(message: "1"), .unauthorized(message: "1"))
         assertEqual(.forbidden(message: "1"), .forbidden(message: "1"))
-        assertEqual(.featureNotFound(message: "1"), .featureNotFound(message: "1"))
+        assertEqual(.notFound(message: "1"), .notFound(message: "1"))
         assertEqual(.invalidHttpMethod(message: "1"), .invalidHttpMethod(message: "1"))
         assertEqual(.clientClosed(message: "1"), .clientClosed(message: "1"))
         assertEqual(.unavailable(message: "1"), .unavailable(message: "1"))
@@ -57,7 +57,7 @@ class BKTErrorTests: XCTestCase {
         assertNotEqual(.badRequest(message: "1"), .badRequest(message: "2"))
         assertNotEqual(.unauthorized(message: "1"), .unauthorized(message: "2"))
         assertNotEqual(.forbidden(message: "1"), .forbidden(message: "2"))
-        assertNotEqual(.featureNotFound(message: "1"), .featureNotFound(message: "2"))
+        assertNotEqual(.notFound(message: "1"), .notFound(message: "2"))
         assertNotEqual(.invalidHttpMethod(message: "1"), .invalidHttpMethod(message: "2"))
         assertNotEqual(.clientClosed(message: "1"), .clientClosed(message: "2"))
         assertNotEqual(.unavailable(message: "1"), .unavailable(message: "2"))
@@ -98,7 +98,7 @@ class BKTErrorTests: XCTestCase {
         )
         assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 404, response: nil)),
-            .featureNotFound(message: "NotFound error")
+            .notFound(message: "NotFound error")
         )
         assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 405, response: nil)),

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -34,6 +34,10 @@ class BKTErrorTests: XCTestCase {
         assertEqual(.illegalArgument(message: "1"), .illegalArgument(message: "1"))
         assertEqual(.illegalState(message: "1"), .illegalState(message: "1"))
         assertEqual(
+            .unknownServer(message: "1", error: SomeError.a),
+            .unknownServer(message: "1", error: SomeError.a)
+        )
+        assertEqual(
             .unknown(message: "1", error: SomeError.a),
             .unknown(message: "1", error: SomeError.a)
         )
@@ -46,6 +50,10 @@ class BKTErrorTests: XCTestCase {
         assertEqual(
             .network(message: "1", error: SomeError.a),
             .network(message: "1", error: SomeError.b)
+        )
+        assertEqual(
+            .unknownServer(message: "1", error: SomeError.a),
+            .unknownServer(message: "1", error: SomeError.b)
         )
         assertEqual(
             .unknown(message: "1", error: SomeError.a),
@@ -70,6 +78,10 @@ class BKTErrorTests: XCTestCase {
         )
         assertNotEqual(.illegalArgument(message: "1"), .illegalArgument(message: "2"))
         assertNotEqual(.illegalState(message: "1"), .illegalState(message: "2"))
+        assertNotEqual(
+            .unknownServer(message: "1", error: SomeError.a),
+            .unknownServer(message: "2", error: SomeError.a)
+        )
         assertNotEqual(
             .unknown(message: "1", error: SomeError.a),
             .unknown(message: "2", error: SomeError.a)
@@ -113,11 +125,11 @@ class BKTErrorTests: XCTestCase {
         let errorResponse = ErrorResponse(error: .init(code: 450, message: "some error"))
         assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 450, response: errorResponse)),
-            .unknown(message: "Unknown error: [450] some error", error: SomeError.a)
+            .unknownServer(message: "Unknown server error: [450] some error", error: SomeError.a)
         )
         assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 450, response: nil)),
-            .unknown(message: "Unknown error: no error body", error: SomeError.a)
+            .unknownServer(message: "Unknown server error: no error body", error: SomeError.a)
         )
 
         assertEqual(

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -96,6 +96,10 @@ class BKTErrorTests: XCTestCase {
             .init(error: ResponseError.unacceptableCode(code: 500, response: nil)),
             .apiServer(message: "InternalServer error")
         )
+        assertEqual(
+            .init(error: ResponseError.unacceptableCode(code: 599, response: nil)),
+            .apiServer(message: "InternalServer error")
+        )
         let errorResponse = ErrorResponse(error: .init(code: 499, message: "some error"))
         assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 499, response: errorResponse)),

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -18,6 +18,7 @@ class BKTErrorTests: XCTestCase {
         // equal
         assertEqual(.badRequest(message: "1"), .badRequest(message: "1"))
         assertEqual(.unauthorized(message: "1"), .unauthorized(message: "1"))
+        assertEqual(.forbidden(message: "1"), .forbidden(message: "1"))
         assertEqual(.invalidHttpMethod(message: "1"), .invalidHttpMethod(message: "1"))
         assertEqual(.apiServer(message: "1"), .apiServer(message: "1"))
         assertEqual(
@@ -52,6 +53,7 @@ class BKTErrorTests: XCTestCase {
         // not equal
         assertNotEqual(.badRequest(message: "1"), .badRequest(message: "2"))
         assertNotEqual(.unauthorized(message: "1"), .unauthorized(message: "2"))
+        assertNotEqual(.forbidden(message: "1"), .forbidden(message: "2"))
         assertNotEqual(.invalidHttpMethod(message: "1"), .invalidHttpMethod(message: "2"))
         assertNotEqual(.apiServer(message: "1"), .apiServer(message: "2"))
         assertNotEqual(
@@ -81,12 +83,12 @@ class BKTErrorTests: XCTestCase {
             .badRequest(message: "BadRequest error")
         )
         assertEqual(
-            .init(error: ResponseError.unacceptableCode(code: 400, response: nil)),
-            .badRequest(message: "BadRequest error")
-        )
-        assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 401, response: nil)),
             .unauthorized(message: "Unauthorized error")
+        )
+        assertEqual(
+            .init(error: ResponseError.unacceptableCode(code: 403, response: nil)),
+            .forbidden(message: "Forbidden error")
         )
         assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 405, response: nil)),

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -21,6 +21,8 @@ class BKTErrorTests: XCTestCase {
         assertEqual(.forbidden(message: "1"), .forbidden(message: "1"))
         assertEqual(.featureNotFound(message: "1"), .featureNotFound(message: "1"))
         assertEqual(.invalidHttpMethod(message: "1"), .invalidHttpMethod(message: "1"))
+        assertEqual(.clientClosed(message: "1"), .clientClosed(message: "1"))
+        assertEqual(.unavailable(message: "1"), .unavailable(message: "1"))
         assertEqual(.apiServer(message: "1"), .apiServer(message: "1"))
         assertEqual(
             .timeout(message: "1", error: SomeError.a),
@@ -57,6 +59,8 @@ class BKTErrorTests: XCTestCase {
         assertNotEqual(.forbidden(message: "1"), .forbidden(message: "2"))
         assertNotEqual(.featureNotFound(message: "1"), .featureNotFound(message: "2"))
         assertNotEqual(.invalidHttpMethod(message: "1"), .invalidHttpMethod(message: "2"))
+        assertNotEqual(.clientClosed(message: "1"), .clientClosed(message: "2"))
+        assertNotEqual(.unavailable(message: "1"), .unavailable(message: "2"))
         assertNotEqual(.apiServer(message: "1"), .apiServer(message: "2"))
         assertNotEqual(
             .timeout(message: "1", error: SomeError.a),
@@ -101,8 +105,16 @@ class BKTErrorTests: XCTestCase {
             .invalidHttpMethod(message: "MethodNotAllowed error")
         )
         assertEqual(
+            .init(error: ResponseError.unacceptableCode(code: 409, response: nil)),
+            .clientClosed(message: "Client Closed Request error")
+        )
+        assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 500, response: nil)),
             .apiServer(message: "InternalServer error")
+        )
+        assertEqual(
+            .init(error: ResponseError.unacceptableCode(code: 503, response: nil)),
+            .unavailable(message: "Unavailable error")
         )
         assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 599, response: nil)),

--- a/BucketeerTests/E2E/BucketeerE2ETests.swift
+++ b/BucketeerTests/E2E/BucketeerE2ETests.swift
@@ -150,6 +150,7 @@ final class BucketeerE2ETests: XCTestCase {
         let client = BKTClient.shared
         client.assert(expectedEventCount: 2)
         client.track(goalId: GOAL_ID, value: GOAL_VALUE)
+        try await Task.sleep(nanoseconds: 1_000_000)
         client.assert(expectedEventCount: 3)
         try await client.flush()
         client.assert(expectedEventCount: 0)

--- a/BucketeerTests/E2E/BucketeerE2ETests.swift
+++ b/BucketeerTests/E2E/BucketeerE2ETests.swift
@@ -22,12 +22,14 @@ final class BucketeerE2ETests: XCTestCase {
         )
     }
 
-    override func tearDown() {
-        super.tearDown()
+    @MainActor
+    override func tearDown() async throws {
+        try await super.tearDown()
 
+        try await BKTClient.shared.flush()
         BKTClient.destroy()
         UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
-        try? FileManager.default.removeItem(at: .database)
+        try FileManager.default.removeItem(at: .database)
     }
 
     func testStringVariation() {

--- a/BucketeerTests/EvaluationInteractorTests.swift
+++ b/BucketeerTests/EvaluationInteractorTests.swift
@@ -33,7 +33,7 @@ final class EvaluationInteractorTests: XCTestCase {
             evaluationDao: dao,
             defaults: defaults,
             idGenerator: idGenerator,
-            config: config
+            featureTag: config.featureTag
         )
         XCTAssertEqual(interactor.currentEvaluationsId, "")
         interactor.fetch(user: .mock1) { result in
@@ -107,7 +107,7 @@ final class EvaluationInteractorTests: XCTestCase {
             evaluationDao: dao,
             defaults: defaults,
             idGenerator: idGenerator,
-            config: config
+            featureTag: config.featureTag
         )
         XCTAssertEqual(interactor.currentEvaluationsId, "")
         // 1st
@@ -166,7 +166,7 @@ final class EvaluationInteractorTests: XCTestCase {
             evaluationDao: dao,
             defaults: defaults,
             idGenerator: idGenerator,
-            config: config
+            featureTag: config.featureTag
         )
         XCTAssertEqual(interactor.currentEvaluationsId, "")
         // 1st
@@ -221,7 +221,7 @@ final class EvaluationInteractorTests: XCTestCase {
             evaluationDao: dao,
             defaults: defaults,
             idGenerator: idGenerator,
-            config: config
+            featureTag: config.featureTag
         )
 
         XCTAssertEqual(interactor.evaluations[userId1], nil)
@@ -259,7 +259,7 @@ final class EvaluationInteractorTests: XCTestCase {
             evaluationDao: dao,
             defaults: defaults,
             idGenerator: idGenerator,
-            config: config
+            featureTag: config.featureTag
         )
 
         try interactor.refreshCache(userId: userId1)
@@ -282,7 +282,7 @@ final class EvaluationInteractorTests: XCTestCase {
             evaluationDao: dao,
             defaults: defaults,
             idGenerator: idGenerator,
-            config: config
+            featureTag: config.featureTag
         )
 
         XCTAssertEqual(interactor.getLatest(userId: User.mock1.id, featureId: Evaluation.mock1.featureId), nil)
@@ -308,7 +308,7 @@ final class EvaluationInteractorTests: XCTestCase {
             evaluationDao: dao,
             defaults: defaults,
             idGenerator: idGenerator,
-            config: config
+            featureTag: config.featureTag
         )
 
         XCTAssertEqual(interactor.getLatest(userId: User.mock1.id, featureId: "invalid_feature_id"), nil)

--- a/BucketeerTests/EvaluationInteractorTests.swift
+++ b/BucketeerTests/EvaluationInteractorTests.swift
@@ -26,12 +26,14 @@ final class EvaluationInteractorTests: XCTestCase {
         let dao = MockEvaluationDao()
         let defaults = MockDefaults()
         let idGenerator = MockIdGenerator(identifier: "")
+        let config = BKTConfig.mock1
 
         let interactor = EvaluationInteractorImpl(
             apiClient: api,
             evaluationDao: dao,
             defaults: defaults,
-            idGenerator: idGenerator
+            idGenerator: idGenerator,
+            config: config
         )
         XCTAssertEqual(interactor.currentEvaluationsId, "")
         interactor.fetch(user: .mock1) { result in
@@ -99,11 +101,13 @@ final class EvaluationInteractorTests: XCTestCase {
         let defaults = MockDefaults()
 
         let idGenerator = MockIdGenerator(identifier: "")
+        let config = BKTConfig.mock1
         let interactor = EvaluationInteractorImpl(
             apiClient: api,
             evaluationDao: dao,
             defaults: defaults,
-            idGenerator: idGenerator
+            idGenerator: idGenerator,
+            config: config
         )
         XCTAssertEqual(interactor.currentEvaluationsId, "")
         // 1st
@@ -155,12 +159,14 @@ final class EvaluationInteractorTests: XCTestCase {
         let dao = MockEvaluationDao()
         let defaults = MockDefaults()
         let idGenerator = MockIdGenerator(identifier: "")
+        let config = BKTConfig.mock1
 
         let interactor = EvaluationInteractorImpl(
             apiClient: api,
             evaluationDao: dao,
             defaults: defaults,
-            idGenerator: idGenerator
+            idGenerator: idGenerator,
+            config: config
         )
         XCTAssertEqual(interactor.currentEvaluationsId, "")
         // 1st
@@ -208,12 +214,14 @@ final class EvaluationInteractorTests: XCTestCase {
         })
         let defaults = MockDefaults()
         let idGenerator = MockIdGenerator(identifier: "")
+        let config = BKTConfig.mock1
 
         let interactor = EvaluationInteractorImpl(
             apiClient: api,
             evaluationDao: dao,
             defaults: defaults,
-            idGenerator: idGenerator
+            idGenerator: idGenerator,
+            config: config
         )
 
         XCTAssertEqual(interactor.evaluations[userId1], nil)
@@ -244,12 +252,14 @@ final class EvaluationInteractorTests: XCTestCase {
         })
         let defaults = MockDefaults()
         let idGenerator = MockIdGenerator(identifier: "")
+        let config = BKTConfig.mock1
 
         let interactor = EvaluationInteractorImpl(
             apiClient: api,
             evaluationDao: dao,
             defaults: defaults,
-            idGenerator: idGenerator
+            idGenerator: idGenerator,
+            config: config
         )
 
         try interactor.refreshCache(userId: userId1)
@@ -265,12 +275,14 @@ final class EvaluationInteractorTests: XCTestCase {
         })
         let defaults = MockDefaults()
         let idGenerator = MockIdGenerator(identifier: "")
+        let config = BKTConfig.mock1
 
         let interactor = EvaluationInteractorImpl(
             apiClient: api,
             evaluationDao: dao,
             defaults: defaults,
-            idGenerator: idGenerator
+            idGenerator: idGenerator,
+            config: config
         )
 
         XCTAssertEqual(interactor.getLatest(userId: User.mock1.id, featureId: Evaluation.mock1.featureId), nil)
@@ -289,12 +301,14 @@ final class EvaluationInteractorTests: XCTestCase {
         })
         let defaults = MockDefaults()
         let idGenerator = MockIdGenerator(identifier: "")
+        let config = BKTConfig.mock1
 
         let interactor = EvaluationInteractorImpl(
             apiClient: api,
             evaluationDao: dao,
             defaults: defaults,
-            idGenerator: idGenerator
+            idGenerator: idGenerator,
+            config: config
         )
 
         XCTAssertEqual(interactor.getLatest(userId: User.mock1.id, featureId: "invalid_feature_id"), nil)

--- a/BucketeerTests/EventDaoTests.swift
+++ b/BucketeerTests/EventDaoTests.swift
@@ -100,6 +100,20 @@ final class EventDaoTests: XCTestCase {
         XCTAssertEqual(events[3], Event.mockEvaluation2)
     }
 
+    func testAddDuplicatedEvents() throws {
+        let db = try SQLite(path: path, logger: nil)
+        let dao = EventDaoImpl(db: db)
+
+        try dao.add(event: .mockMetrics1)
+        try dao.add(event: .mockMetrics2)
+        try dao.add(event: .mockMetrics3)
+
+        let events = try dao.getEvents()
+        XCTAssertEqual(events.count, 2)
+        XCTAssertEqual(events[0], Event.mockMetrics1)
+        XCTAssertEqual(events[1], Event.mockMetrics2)
+    }
+
     func testDeleteAll() throws {
         let db = try SQLite(path: path, logger: nil)
         let dao = EventDaoImpl(db: db)

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -154,7 +154,7 @@ final class EventInteractorTests: XCTestCase {
                         event: .getEvaluationLatency(.init(
                             apiId: .getEvaluations,
                             labels: ["tag": "featureTag1"],
-                            duration: .init(seconds: 10)
+                            duration: .init(10)
                         )),
                         type: .getEvaluationLatency,
                         sdk_version: "0.0.2",

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -171,12 +171,12 @@ final class EventInteractorTests: XCTestCase {
                     id: "id",
                     event: .metrics(.init(
                         timestamp: 1,
-                        event: .getEvaluationSize(.init(
+                        event: .responseSize(.init(
                             apiId: .getEvaluations,
                             labels: ["tag": "featureTag1"],
                             size_byte: 100
                         )),
-                        type: .getEvaluationSize,
+                        type: .responseSize,
                         sdk_version: "0.0.2",
                         metadata: [
                             "app_version": "1.2.3",

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -157,6 +157,7 @@ final class EventInteractorTests: XCTestCase {
                             latencySecond: .init(10)
                         )),
                         type: .responseLatency,
+                        sourceId: .ios,
                         sdk_version: "0.0.2",
                         metadata: [
                             "app_version": "1.2.3",
@@ -177,6 +178,7 @@ final class EventInteractorTests: XCTestCase {
                             size_byte: 100
                         )),
                         type: .responseSize,
+                        sourceId: .ios,
                         sdk_version: "0.0.2",
                         metadata: [
                             "app_version": "1.2.3",
@@ -218,6 +220,7 @@ final class EventInteractorTests: XCTestCase {
                         timestamp: 1,
                         event: .timeoutError(.init(apiId: .getEvaluations, labels: ["tag": "featureTag1"])),
                         type: .timeoutError,
+                        sourceId: .ios,
                         sdk_version: "0.0.2",
                         metadata: [
                             "app_version": "1.2.3",
@@ -254,6 +257,7 @@ final class EventInteractorTests: XCTestCase {
                         timestamp: 1,
                         event: .badRequestError(.init(apiId: .getEvaluations, labels: ["tag": "featureTag1"])),
                         type: .badRequestError,
+                        sourceId: .ios,
                         sdk_version: "0.0.2",
                         metadata: [
                             "app_version": "1.2.3",

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -154,7 +154,7 @@ final class EventInteractorTests: XCTestCase {
                         event: .getEvaluationLatency(.init(
                             apiId: .getEvaluations,
                             labels: ["tag": "featureTag1"],
-                            duration: .init(10)
+                            latencySecond: .init(10)
                         )),
                         type: .getEvaluationLatency,
                         sdk_version: "0.0.2",

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -252,8 +252,8 @@ final class EventInteractorTests: XCTestCase {
                     id: "id",
                     event: .metrics(.init(
                         timestamp: 1,
-                        event: .internalSdkError(.init(apiId: .getEvaluations, labels: ["tag": "featureTag1"])),
-                        type: .internalError,
+                        event: .badRequestError(.init(apiId: .getEvaluations, labels: ["tag": "featureTag1"])),
+                        type: .badRequestError,
                         sdk_version: "0.0.2",
                         metadata: [
                             "app_version": "1.2.3",

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -151,12 +151,12 @@ final class EventInteractorTests: XCTestCase {
                     id: "id",
                     event: .metrics(.init(
                         timestamp: 1,
-                        event: .getEvaluationLatency(.init(
+                        event: .responseLatency(.init(
                             apiId: .getEvaluations,
                             labels: ["tag": "featureTag1"],
                             latencySecond: .init(10)
                         )),
-                        type: .getEvaluationLatency,
+                        type: .responseLatency,
                         sdk_version: "0.0.2",
                         metadata: [
                             "app_version": "1.2.3",

--- a/BucketeerTests/JSONDecodingTests.swift
+++ b/BucketeerTests/JSONDecodingTests.swift
@@ -115,10 +115,7 @@ class JSONDecodingTests: XCTestCase {
                 "key_1": "value_1",
                 "key_2": "value_2",
             },
-            "duration": {
-                "seconds": 1,
-                "nanos": 2
-            }
+            "duration": 1
         }
     }
 }
@@ -143,7 +140,7 @@ class JSONDecodingTests: XCTestCase {
         }
         XCTAssertEqual(metricsData.labels["key_1"], "value_1")
         XCTAssertEqual(metricsData.labels["key_2"], "value_2")
-        XCTAssertEqual(metricsData.duration.seconds, 1)
+        XCTAssertEqual(metricsData.duration, 1)
     }
 
     func testDecodingMetricsGetEvaluationSizeEvent() throws {

--- a/BucketeerTests/JSONDecodingTests.swift
+++ b/BucketeerTests/JSONDecodingTests.swift
@@ -143,7 +143,7 @@ class JSONDecodingTests: XCTestCase {
         XCTAssertEqual(metricsData.latencySecond, 1)
     }
 
-    func testDecodingMetricsGetEvaluationSizeEvent() throws {
+    func testDecodingMetricsResponseSizeEvent() throws {
         let json = """
 {
     "id": "event_1",
@@ -175,8 +175,8 @@ class JSONDecodingTests: XCTestCase {
             return
         }
         XCTAssertEqual(eventData.timestamp, 1)
-        XCTAssertEqual(eventData.type, .getEvaluationSize)
-        guard case .getEvaluationSize(let metricsData) = eventData.event else {
+        XCTAssertEqual(eventData.type, .responseSize)
+        guard case .responseSize(let metricsData) = eventData.event else {
             XCTFail("metricsData is invalid")
             return
         }

--- a/BucketeerTests/JSONDecodingTests.swift
+++ b/BucketeerTests/JSONDecodingTests.swift
@@ -115,7 +115,7 @@ class JSONDecodingTests: XCTestCase {
                 "key_1": "value_1",
                 "key_2": "value_2",
             },
-            "duration": 1
+            "latencySecond": 1
         }
     }
 }
@@ -140,7 +140,7 @@ class JSONDecodingTests: XCTestCase {
         }
         XCTAssertEqual(metricsData.labels["key_1"], "value_1")
         XCTAssertEqual(metricsData.labels["key_2"], "value_2")
-        XCTAssertEqual(metricsData.duration, 1)
+        XCTAssertEqual(metricsData.latencySecond, 1)
     }
 
     func testDecodingMetricsGetEvaluationSizeEvent() throws {

--- a/BucketeerTests/JSONDecodingTests.swift
+++ b/BucketeerTests/JSONDecodingTests.swift
@@ -192,7 +192,7 @@ class JSONDecodingTests: XCTestCase {
     "type": 4,
     "event": {
         "timestamp": 1,
-        "type": 5,
+        "type": 3,
         "event": {
             "apiId": 2,
             "labels": {
@@ -230,7 +230,7 @@ class JSONDecodingTests: XCTestCase {
     "type": 4,
     "event": {
         "timestamp": 1,
-        "type": 7,
+        "type": 5,
         "event": {
             "apiId": 2,
             "labels": {

--- a/BucketeerTests/JSONDecodingTests.swift
+++ b/BucketeerTests/JSONDecodingTests.swift
@@ -101,7 +101,7 @@ class JSONDecodingTests: XCTestCase {
         XCTAssertEqual(eventData.sourceId, .ios)
     }
 
-    func testDecodingMetricsGetEvaluationLatencyEvent() throws {
+    func testDecodingMetricsResponseLatencyEvent() throws {
         let json = """
 {
     "id": "event_1",
@@ -133,8 +133,8 @@ class JSONDecodingTests: XCTestCase {
             return
         }
         XCTAssertEqual(eventData.timestamp, 1)
-        XCTAssertEqual(eventData.type, .getEvaluationLatency)
-        guard case .getEvaluationLatency(let metricsData) = eventData.event else {
+        XCTAssertEqual(eventData.type, .responseLatency)
+        guard case .responseLatency(let metricsData) = eventData.event else {
             XCTFail("metricsData is invalid")
             return
         }

--- a/BucketeerTests/JSONDecodingTests.swift
+++ b/BucketeerTests/JSONDecodingTests.swift
@@ -109,6 +109,7 @@ class JSONDecodingTests: XCTestCase {
     "event": {
         "timestamp": 1,
         "type": 1,
+        "sourceId": 2,
         "event": {
             "apiId": 2,
             "labels": {
@@ -151,6 +152,7 @@ class JSONDecodingTests: XCTestCase {
     "event": {
         "timestamp": 1,
         "type": 2,
+        "sourceId": 2,
         "event": {
             "apiId": 2,
             "labels": {
@@ -193,6 +195,7 @@ class JSONDecodingTests: XCTestCase {
     "event": {
         "timestamp": 1,
         "type": 3,
+        "sourceId": 2,
         "event": {
             "apiId": 2,
             "labels": {
@@ -231,6 +234,7 @@ class JSONDecodingTests: XCTestCase {
     "event": {
         "timestamp": 1,
         "type": 5,
+        "sourceId": 2,
         "event": {
             "apiId": 2,
             "labels": {

--- a/BucketeerTests/Mock/MockEvaluationInteractor.swift
+++ b/BucketeerTests/Mock/MockEvaluationInteractor.swift
@@ -16,7 +16,7 @@ struct MockEvaluationInteractor: EvaluationInteractor {
     func refreshCache(userId: String) throws {
 
     }
-    func resetCurrentEvaluationsId() {
+    func clearCurrentEvaluationsId() {
 
     }
     func addUpdateListener(listener: Bucketeer.EvaluationUpdateListener) -> String {

--- a/BucketeerTests/Mock/MockEvaluationInteractor.swift
+++ b/BucketeerTests/Mock/MockEvaluationInteractor.swift
@@ -5,6 +5,8 @@ struct MockEvaluationInteractor: EvaluationInteractor {
     typealias FetchHandler = (_ user: User, _ timeoutMillis: Int64?, _ completion: ((GetEvaluationsResult) -> Void)?) -> Void
 
     var fetchHandler: FetchHandler?
+    var currentEvaluationsId: String = ""
+
     func fetch(user: User, timeoutMillis: Int64?, completion: ((GetEvaluationsResult) -> Void)?) {
         fetchHandler?(user, timeoutMillis, completion)
     }
@@ -12,6 +14,9 @@ struct MockEvaluationInteractor: EvaluationInteractor {
         fatalError()
     }
     func refreshCache(userId: String) throws {
+
+    }
+    func resetCurrentEvaluationsId() {
 
     }
     func addUpdateListener(listener: Bucketeer.EvaluationUpdateListener) -> String {

--- a/BucketeerTests/Mock/MockEventInteractor.swift
+++ b/BucketeerTests/Mock/MockEventInteractor.swift
@@ -3,7 +3,7 @@ import Foundation
 
 final class MockEventInteractor: EventInteractor {
     typealias SendEventsHandler = (_ force: Bool, _ completion: ((Result<Bool, BKTError>) -> Void)?) -> Void
-    typealias TrackEvaluationSuccessHandler = (_ featureTag: String, _ seconds: Int64, _ sizeByte: Int64) throws -> Void
+    typealias TrackEvaluationSuccessHandler = (_ featureTag: String, _ seconds: Float64, _ sizeByte: Int64) throws -> Void
     typealias TrackEvaluationFailureHandler = (_ featureTag: String, _ error: BKTError) throws -> Void
     typealias TrackRegisterEventFailureHandler = (_ error: BKTError) throws -> Void
 
@@ -37,7 +37,7 @@ final class MockEventInteractor: EventInteractor {
     func trackGoalEvent(featureTag: String, user: User, goalId: String, value: Double) throws {
 
     }
-    func trackFetchEvaluationsSuccess(featureTag: String, seconds: Int64, sizeByte: Int64) throws {
+    func trackFetchEvaluationsSuccess(featureTag: String, seconds: Float64, sizeByte: Int64) throws {
         try trackEvaluationSuccessHandler?(featureTag, seconds, sizeByte)
     }
     func trackFetchEvaluationsFailure(featureTag: String, error: BKTError) throws {

--- a/BucketeerTests/Mock/MockEventInteractor.swift
+++ b/BucketeerTests/Mock/MockEventInteractor.swift
@@ -3,7 +3,7 @@ import Foundation
 
 final class MockEventInteractor: EventInteractor {
     typealias SendEventsHandler = (_ force: Bool, _ completion: ((Result<Bool, BKTError>) -> Void)?) -> Void
-    typealias TrackEvaluationSuccessHandler = (_ featureTag: String, _ seconds: Float64, _ sizeByte: Int64) throws -> Void
+    typealias TrackEvaluationSuccessHandler = (_ featureTag: String, _ seconds: Double, _ sizeByte: Int64) throws -> Void
     typealias TrackEvaluationFailureHandler = (_ featureTag: String, _ error: BKTError) throws -> Void
     typealias TrackRegisterEventFailureHandler = (_ error: BKTError) throws -> Void
 
@@ -37,7 +37,7 @@ final class MockEventInteractor: EventInteractor {
     func trackGoalEvent(featureTag: String, user: User, goalId: String, value: Double) throws {
 
     }
-    func trackFetchEvaluationsSuccess(featureTag: String, seconds: Float64, sizeByte: Int64) throws {
+    func trackFetchEvaluationsSuccess(featureTag: String, seconds: Double, sizeByte: Int64) throws {
         try trackEvaluationSuccessHandler?(featureTag, seconds, sizeByte)
     }
     func trackFetchEvaluationsFailure(featureTag: String, error: BKTError) throws {

--- a/BucketeerTests/Mock/MockEventInteractor.swift
+++ b/BucketeerTests/Mock/MockEventInteractor.swift
@@ -5,20 +5,24 @@ final class MockEventInteractor: EventInteractor {
     typealias SendEventsHandler = (_ force: Bool, _ completion: ((Result<Bool, BKTError>) -> Void)?) -> Void
     typealias TrackEvaluationSuccessHandler = (_ featureTag: String, _ seconds: Int64, _ sizeByte: Int64) throws -> Void
     typealias TrackEvaluationFailureHandler = (_ featureTag: String, _ error: BKTError) throws -> Void
+    typealias TrackRegisterEventFailureHandler = (_ error: BKTError) throws -> Void
 
     var eventUpdateListener: EventUpdateListener?
     var sendEventsHandler: SendEventsHandler?
     var trackEvaluationSuccessHandler: TrackEvaluationSuccessHandler?
     var trackEvaluationFailureHandler: TrackEvaluationFailureHandler?
+    var trackRegisterEventFailureHandler: TrackRegisterEventFailureHandler?
 
     init(eventUpdateListener: EventUpdateListener? = nil,
          sendEventsHandler: SendEventsHandler? = nil,
          trackEvaluationSuccessHandler: TrackEvaluationSuccessHandler? = nil,
-         trackEvaluationFailureHandler: TrackEvaluationFailureHandler? = nil) {
+         trackEvaluationFailureHandler: TrackEvaluationFailureHandler? = nil,
+         trackRegisterEventFailureHandler: TrackRegisterEventFailureHandler? = nil) {
         self.eventUpdateListener = eventUpdateListener
         self.sendEventsHandler = sendEventsHandler
         self.trackEvaluationSuccessHandler = trackEvaluationSuccessHandler
         self.trackEvaluationFailureHandler = trackEvaluationFailureHandler
+        self.trackRegisterEventFailureHandler = trackRegisterEventFailureHandler
     }
 
     func set(eventUpdateListener: EventUpdateListener?) {
@@ -38,6 +42,9 @@ final class MockEventInteractor: EventInteractor {
     }
     func trackFetchEvaluationsFailure(featureTag: String, error: BKTError) throws {
         try trackEvaluationFailureHandler?(featureTag, error)
+    }
+    func trackRegisterEventsFailure(error: BKTError) throws {
+        try trackRegisterEventFailureHandler?(error)
     }
     func sendEvents(force: Bool, completion: ((Result<Bool, BKTError>) -> Void)?) {
         sendEventsHandler?(force, completion)

--- a/BucketeerTests/Mock/MockEvents.swift
+++ b/BucketeerTests/Mock/MockEvents.swift
@@ -100,6 +100,7 @@ extension Event {
                 latencySecond: .init(2)
             )),
             type: .responseLatency,
+            sourceId: .ios,
             sdk_version: "0.0.1",
             metadata: [
                 "app_version": "1.2.3",
@@ -120,6 +121,7 @@ extension Event {
                 labels: [:]
             )),
             type: .internalServerError,
+            sourceId: .ios,
             sdk_version: "0.0.1",
             metadata: [
                 "app_version": "1.2.3",
@@ -140,6 +142,7 @@ extension Event {
                 labels: [:]
             )),
             type: .internalServerError,
+            sourceId: .ios,
             sdk_version: "0.0.1",
             metadata: [
                 "app_version": "1.2.3",

--- a/BucketeerTests/Mock/MockEvents.swift
+++ b/BucketeerTests/Mock/MockEvents.swift
@@ -94,12 +94,12 @@ extension Event {
         id: "metrics_event1",
         event: .metrics(.init(
             timestamp: 1,
-            event: .getEvaluationLatency(.init(
+            event: .responseLatency(.init(
                 apiId: .getEvaluations,
                 labels: ["tag": "ios", "state": "full"],
                 latencySecond: .init(2)
             )),
-            type: .getEvaluationLatency,
+            type: .responseLatency,
             sdk_version: "0.0.1",
             metadata: [
                 "app_version": "1.2.3",

--- a/BucketeerTests/Mock/MockEvents.swift
+++ b/BucketeerTests/Mock/MockEvents.swift
@@ -97,7 +97,7 @@ extension Event {
             event: .getEvaluationLatency(.init(
                 apiId: .getEvaluations,
                 labels: ["tag": "ios", "state": "full"],
-                duration: .init(seconds: 2)
+                duration: .init(2)
             )),
             type: .getEvaluationLatency,
             sdk_version: "0.0.1",

--- a/BucketeerTests/Mock/MockEvents.swift
+++ b/BucketeerTests/Mock/MockEvents.swift
@@ -97,7 +97,7 @@ extension Event {
             event: .getEvaluationLatency(.init(
                 apiId: .getEvaluations,
                 labels: ["tag": "ios", "state": "full"],
-                duration: .init(2)
+                latencySecond: .init(2)
             )),
             type: .getEvaluationLatency,
             sdk_version: "0.0.1",

--- a/BucketeerTests/Mock/MockEvents.swift
+++ b/BucketeerTests/Mock/MockEvents.swift
@@ -110,4 +110,44 @@ extension Event {
         )),
         type: .metrics
     )
+
+    static let mockMetrics2 = Event(
+        id: "metrics_event2",
+        event: .metrics(.init(
+            timestamp: 1,
+            event: .internalServerError(.init(
+                apiId: .registerEvents,
+                labels: [:]
+            )),
+            type: .internalServerError,
+            sdk_version: "0.0.1",
+            metadata: [
+                "app_version": "1.2.3",
+                "os_version": "16.0",
+                "device_model": "iPhone14,7",
+                "device_type": "mobile"
+            ]
+        )),
+        type: .metrics
+    )
+
+    static let mockMetrics3 = Event(
+        id: "metrics_event3",
+        event: .metrics(.init(
+            timestamp: 2,
+            event: .internalServerError(.init(
+                apiId: .registerEvents,
+                labels: [:]
+            )),
+            type: .internalServerError,
+            sdk_version: "0.0.1",
+            metadata: [
+                "app_version": "1.2.3",
+                "os_version": "16.0",
+                "device_model": "iPhone14,7",
+                "device_type": "mobile"
+            ]
+        )),
+        type: .metrics
+    )
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 confirm_api_url () {
-    echo "Please input your API_URL. e.g. Please change this to https://api.bucketeer.io"
+    echo "Please input your API_URL. e.g. https://api.bucketeer.io"
     read input
 
     if [ -z $input ]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 confirm_api_url () {
-    echo "Please input your API_URL. e.g. https://api-media.bucketeer.jp"
+    echo "Please input your API_URL. e.g. https://api.bucketeer.jp"
     read input
 
     if [ -z $input ]; then
@@ -20,7 +20,7 @@ confirm_sdk_key () {
     SDK_KEY=$input
 }
 
-if [ $CI = false ]; then
+if [ "$CI" = "" ]; then
     confirm_api_url
     confirm_sdk_key
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 confirm_api_url () {
-    echo "Please input your API_URL. e.g. https://api.bucketeer.jp"
+    echo "Please input your API_URL. e.g. Please change this to https://api.bucketeer.io"
     read input
 
     if [ -z $input ]; then


### PR DESCRIPTION
- [x] remove old endpoint
- [x] improve error handling
     - [x] remove 404
     - [x] add 5xx
     - [x] add 403
- [x] reset evaluation id after `updateUserAttributes`
- [x] store `registerEvents` error metrics
- [x] avoid storing duplicated metrics events